### PR TITLE
Add save/load functions

### DIFF
--- a/Code/header.html
+++ b/Code/header.html
@@ -1,6 +1,9 @@
 <header class="top-menu">
     <button>管理室</button>
     <button>日報</button>
+    <button id="save-button">セーブ</button>
+    <button id="load-button">ロード</button>
+    <input type="file" id="load-file-input" accept="application/json" style="display:none">
     <div class="datetime">
         <span id="time">19:00:00</span>
         <span id="date">2025/06/29</span>

--- a/Code/js/app-init.js
+++ b/Code/js/app-init.js
@@ -2,6 +2,8 @@ import { initDomCache, dom } from './dom-cache.js';
 import { setupEventListeners } from './event-listeners.js';
 import { renderCharacters } from './character-render.js';
 import { switchView, alignAllSliderTicks } from './view-switcher.js';
+import { loadState } from './storage.js';
+import { state } from './state.js';
 
 function updateDateTime() {
     const now = new Date();
@@ -23,6 +25,10 @@ export async function loadHTML(id, file) {
 
 export async function initializeApp() {
     initDomCache();
+    const saved = loadState();
+    if (saved) {
+        Object.assign(state, saved);
+    }
     setupEventListeners();
     setInterval(updateDateTime, 1000);
     updateDateTime();

--- a/Code/js/dom-cache.js
+++ b/Code/js/dom-cache.js
@@ -16,6 +16,9 @@ export function initDomCache() {
     dom.managementRoomView = document.getElementById('management-room');
     dom.backToMainButton = document.getElementById('back-to-main-button');
     dom.managementButton = document.querySelector('.top-menu button:first-child');
+    dom.saveButton = document.getElementById('save-button');
+    dom.loadButton = document.getElementById('load-button');
+    dom.loadFileInput = document.getElementById('load-file-input');
 
     dom.addCharacterForm = document.getElementById('add-character-form');
     dom.charNameInput = document.getElementById('char-name');

--- a/Code/js/event-listeners.js
+++ b/Code/js/event-listeners.js
@@ -1,13 +1,30 @@
 import { dom, initDomCache } from './dom-cache.js';
 import { switchView, alignAllSliderTicks } from './view-switcher.js';
 import { calculateMbti } from './mbti-diagnosis.js';
-import { renderCharacters } from './character-render.js';
+import { renderCharacters, renderManagementList } from './character-render.js';
 import { setupFormHandlers } from './form-handler.js';
 import { state, mbtiDescriptions } from './state.js';
+import { exportState, importStateFromFile } from './storage.js';
 
 export function setupEventListeners() {
     dom.managementButton.addEventListener('click', () => switchView('management'));
     dom.backToMainButton.addEventListener('click', () => switchView('main'));
+    dom.saveButton.addEventListener('click', () => exportState(state));
+    dom.loadButton.addEventListener('click', () => dom.loadFileInput.click());
+    dom.loadFileInput.addEventListener('change', (e) => {
+        const file = e.target.files[0];
+        if (!file) return;
+        importStateFromFile(file)
+            .then(loaded => {
+                Object.assign(state, loaded);
+                renderCharacters();
+                renderManagementList();
+            })
+            .catch(() => alert('読み込みに失敗しました。'))
+            .finally(() => {
+                dom.loadFileInput.value = '';
+            });
+    });
 
     dom.startDiagButton.addEventListener('click', () => {
         dom.mbtiQuestionsArea.style.display = 'block';

--- a/Code/js/form-handler.js
+++ b/Code/js/form-handler.js
@@ -4,6 +4,7 @@ import { calculateMbti } from './mbti-diagnosis.js';
 import { renderCharacters, renderManagementList } from './character-render.js';
 import { renderRelationshipEditor, updateConfiguredRelationshipsList, clearRelationshipInputs } from './relationship-editor.js';
 import { switchView, resetFormState, alignAllSliderTicks } from './view-switcher.js';
+import { saveState } from './storage.js';
 
 export function setupFormHandlers() {
     dom.addCharacterForm.addEventListener('submit', (event) => {
@@ -82,6 +83,7 @@ export function setupFormHandlers() {
 
         renderCharacters();
         renderManagementList();
+        saveState(state);
         switchView('main');
     });
 
@@ -110,6 +112,7 @@ export function setupFormHandlers() {
                 state.characters = state.characters.filter(char => char.id !== idToDelete);
                 renderManagementList();
                 renderCharacters();
+                saveState(state);
             }
         } else if (event.target.classList.contains('edit-button')) {
             const idToEdit = event.target.dataset.id;

--- a/Code/js/storage.js
+++ b/Code/js/storage.js
@@ -1,0 +1,48 @@
+const STORAGE_KEY = 'relation_sim_state';
+
+export function saveState(state) {
+    try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    } catch (e) {
+        console.error('状態の保存に失敗しました', e);
+    }
+}
+
+export function loadState() {
+    const data = localStorage.getItem(STORAGE_KEY);
+    if (!data) return null;
+    try {
+        return JSON.parse(data);
+    } catch (e) {
+        console.error('保存データの読み込みに失敗しました', e);
+        return null;
+    }
+}
+
+export function exportState(state) {
+    const blob = new Blob([JSON.stringify(state, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'state.json';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+}
+
+export function importStateFromFile(file) {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => {
+            try {
+                const data = JSON.parse(reader.result);
+                resolve(data);
+            } catch (e) {
+                reject(e);
+            }
+        };
+        reader.onerror = () => reject(reader.error);
+        reader.readAsText(file);
+    });
+}


### PR DESCRIPTION
## Summary
- 保存と読み込みを行う `storage.js` を追加
- ヘッダーにセーブ・ロードボタンを設置
- ローカルストレージから状態を復元するよう `app-init.js` を更新
- 状態変更時に自動保存するよう `form-handler.js` を修正
- セーブ/ロードのイベント処理を `event-listeners.js` へ追加
- DOM キャッシュに新しい要素を登録

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6871374a1d6c833386d706f5ed965ace