### PR TITLE
Fix slider tick alignment

### DIFF
--- a/Code/js/app-init.js
+++ b/Code/js/app-init.js
@@ -34,7 +34,7 @@ export async function initializeApp() {
     updateDateTime();
     renderCharacters();
     switchView('main');
-    alignAllSliderTicks();
+    requestAnimationFrame(alignAllSliderTicks);
 }
 
 export async function setupApp() {

--- a/Code/js/event-listeners.js
+++ b/Code/js/event-listeners.js
@@ -30,7 +30,7 @@ export function setupEventListeners() {
         dom.mbtiQuestionsArea.style.display = 'block';
         dom.startDiagButton.style.display = 'none';
         dom.mbtiResultArea.style.display = 'none';
-        setTimeout(alignAllSliderTicks, 0);
+        requestAnimationFrame(alignAllSliderTicks);
     });
 
     dom.executeDiagButton.addEventListener('click', () => {

--- a/Code/js/form-handler.js
+++ b/Code/js/form-handler.js
@@ -103,6 +103,7 @@ export function setupFormHandlers() {
         dom.addCharacterForm.dataset.newId = 'char_' + Date.now();
         state.tempRelations = {};
         renderRelationshipEditor();
+        requestAnimationFrame(alignAllSliderTicks);
     });
 
     dom.managementCharacterList.addEventListener('click', (event) => {
@@ -142,6 +143,7 @@ export function setupFormHandlers() {
                 dom.showAddFormButton.style.display = 'none';
                 dom.interestsInput.value = characterToEdit.interests ? characterToEdit.interests.join(', ') : '';
                 dom.addCharacterForm.scrollIntoView({ behavior: 'smooth' });
+                requestAnimationFrame(alignAllSliderTicks);
             }
             state.tempRelations = {};
             const existingRelations = state.relationships.filter(r => r.pair.includes(idToEdit));

--- a/Code/js/view-switcher.js
+++ b/Code/js/view-switcher.js
@@ -6,7 +6,7 @@ export function switchView(viewToShow) {
     if (viewToShow === 'management') {
         dom.mainViewSections.forEach(section => section.style.display = 'none');
         dom.managementRoomView.style.display = 'block';
-        alignAllSliderTicks();
+        requestAnimationFrame(alignAllSliderTicks);
         renderManagementList();
         resetFormState();
     } else {


### PR DESCRIPTION
## Summary
- adjust slider tick alignment after DOM layout is ready
- rerender ticks when the add form or edit form is displayed
- update MBTI diagnosis start button behavior

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68713ec8b3fc8333a7d686b8065b6e2a