### PR TITLE
ステータス画面の追加

### DIFF
--- a/Code/character-status.html
+++ b/Code/character-status.html
@@ -1,0 +1,22 @@
+<section id="character-status-view" class="view">
+    <h2>▼ ステータス</h2>
+    <div class="basic-info">
+        <p>名前: <span id="status-name"></span></p>
+        <p>MBTI: <span id="status-mbti"></span></p>
+        <p>話し方: <span id="status-talk"></span></p>
+        <p>現在状態: <span id="status-condition"></span></p>
+    </div>
+    <h3>▼ 性格パラメータ</h3>
+    <ul>
+        <li>社交性: <span id="status-social"></span></li>
+        <li>気配り傾向: <span id="status-kindness"></span></li>
+        <li>頑固さ: <span id="status-stubbornness"></span></li>
+        <li>行動力: <span id="status-activity"></span></li>
+        <li>表現力: <span id="status-expressiveness"></span></li>
+    </ul>
+    <h3>▼ 関係一覧</h3>
+    <div id="status-relations"></div>
+    <h3>▼ イベント履歴</h3>
+    <ul id="status-events"></ul>
+    <button id="back-to-main-from-status">メインに戻る</button>
+</section>

--- a/Code/index.html
+++ b/Code/index.html
@@ -16,6 +16,7 @@
         <main>
             <div id="main-view-placeholder"></div>
             <div id="management-room-placeholder"></div>
+            <div id="status-view-placeholder"></div>
         </main>
     </div>
 

--- a/Code/js/app-init.js
+++ b/Code/js/app-init.js
@@ -41,5 +41,6 @@ export async function setupApp() {
     await loadHTML('header-placeholder', 'header.html');
     await loadHTML('main-view-placeholder', 'main-view.html');
     await loadHTML('management-room-placeholder', 'management-view.html');
+    await loadHTML('status-view-placeholder', 'character-status.html');
     await initializeApp();
 }

--- a/Code/js/character-render.js
+++ b/Code/js/character-render.js
@@ -1,5 +1,6 @@
 import { dom } from './dom-cache.js';
 import { state } from './state.js';
+import { switchView } from './view-switcher.js';
 
 export function renderCharacters() {
     dom.characterListElement.innerHTML = '';
@@ -7,6 +8,7 @@ export function renderCharacters() {
         const card = document.createElement('div');
         card.className = 'character-card';
         card.textContent = char.name;
+        card.addEventListener('click', () => showCharacterStatus(char));
         dom.characterListElement.appendChild(card);
     });
 }
@@ -37,4 +39,28 @@ export function renderManagementList() {
         listItem.appendChild(actionsDiv);
         dom.managementCharacterList.appendChild(listItem);
     });
+}
+
+function levelToBars(level) {
+    const filled = '■'.repeat(level);
+    const empty = '□'.repeat(5 - level);
+    return filled + empty;
+}
+
+function showCharacterStatus(char) {
+    dom.statusName.textContent = char.name;
+    dom.statusMbti.textContent = char.mbti;
+    const style = char.talk_style;
+    dom.statusTalk.textContent = `${style.preset}（${style.first_person}, ${style.suffix}）`;
+    dom.statusCondition.textContent = '活動中';
+    const p = char.personality;
+    dom.statusPersonality.social.textContent = levelToBars(p.social);
+    dom.statusPersonality.kindness.textContent = levelToBars(p.kindness);
+    dom.statusPersonality.stubbornness.textContent = levelToBars(p.stubbornness);
+    dom.statusPersonality.activity.textContent = levelToBars(p.activity);
+    dom.statusPersonality.expressiveness.textContent = levelToBars(p.expressiveness);
+    // 関係・イベントは未実装のため空にする
+    dom.statusRelations.textContent = '';
+    dom.statusEvents.textContent = '';
+    switchView('status');
 }

--- a/Code/js/dom-cache.js
+++ b/Code/js/dom-cache.js
@@ -70,4 +70,21 @@ export function initDomCache() {
     dom.mbtiQuestionsArea = document.getElementById('mbti-questions-area');
     dom.mbtiResultArea = document.getElementById('mbti-result-area');
     dom.mbtiResultText = document.getElementById('mbti-result-text');
+
+    // ステータス画面要素
+    dom.statusView = document.getElementById('character-status-view');
+    dom.statusBackButton = document.getElementById('back-to-main-from-status');
+    dom.statusName = document.getElementById('status-name');
+    dom.statusMbti = document.getElementById('status-mbti');
+    dom.statusTalk = document.getElementById('status-talk');
+    dom.statusCondition = document.getElementById('status-condition');
+    dom.statusPersonality = {
+        social: document.getElementById('status-social'),
+        kindness: document.getElementById('status-kindness'),
+        stubbornness: document.getElementById('status-stubbornness'),
+        activity: document.getElementById('status-activity'),
+        expressiveness: document.getElementById('status-expressiveness'),
+    };
+    dom.statusRelations = document.getElementById('status-relations');
+    dom.statusEvents = document.getElementById('status-events');
 }

--- a/Code/js/event-listeners.js
+++ b/Code/js/event-listeners.js
@@ -9,6 +9,7 @@ import { exportState, importStateFromFile } from './storage.js';
 export function setupEventListeners() {
     dom.managementButton.addEventListener('click', () => switchView('management'));
     dom.backToMainButton.addEventListener('click', () => switchView('main'));
+    dom.statusBackButton.addEventListener('click', () => switchView('main'));
     dom.saveButton.addEventListener('click', () => exportState(state));
     dom.loadButton.addEventListener('click', () => dom.loadFileInput.click());
     dom.loadFileInput.addEventListener('change', (e) => {

--- a/Code/js/view-switcher.js
+++ b/Code/js/view-switcher.js
@@ -5,12 +5,18 @@ import { renderManagementList } from './character-render.js';
 export function switchView(viewToShow) {
     if (viewToShow === 'management') {
         dom.mainViewSections.forEach(section => section.style.display = 'none');
+        dom.statusView.style.display = 'none';
         dom.managementRoomView.style.display = 'block';
         requestAnimationFrame(alignAllSliderTicks);
         renderManagementList();
         resetFormState();
+    } else if (viewToShow === 'status') {
+        dom.mainViewSections.forEach(section => section.style.display = 'none');
+        dom.managementRoomView.style.display = 'none';
+        dom.statusView.style.display = 'block';
     } else {
         dom.managementRoomView.style.display = 'none';
+        dom.statusView.style.display = 'none';
         dom.mainViewSections.forEach(section => section.style.display = 'block');
         resetFormState();
     }


### PR DESCRIPTION
## Summary
- 新規HTML `character-status.html` を追加し、キャラの情報表示用レイアウトを実装
- `view-switcher.js` に `status` ビューを追加し画面切り替えを拡張
- キャラクターカードをクリックするとステータス画面へ遷移するよう `character-render.js` を更新
- DOMキャッシュやイベントリスナーをステータス画面に対応
- 初期化時にステータス画面のHTMLを読み込むように変更

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6871411b7d4483338b8995b7e3182b5b