### PR TITLE
Fix daily report feature

### DIFF
--- a/Code/css/components.css
+++ b/Code/css/components.css
@@ -295,3 +295,17 @@ input[type="range"]::-moz-range-thumb {
 #configured-relationships-list .delete-relation-button {
     margin-left: 5px;
 }
+/* 日報画面 */
+#daily-report-list {
+    list-style: none;
+    padding-left: 0;
+}
+
+#daily-report-view input[type="date"] {
+    color: #e0e0e0;
+    background-color: #3d3d3d;
+    border: 1px solid #555;
+    border-radius: 4px;
+    padding: 4px 8px;
+    cursor: pointer;
+}

--- a/Code/daily-report.html
+++ b/Code/daily-report.html
@@ -1,0 +1,10 @@
+<section id="daily-report-view" class="view">
+    <h2>▼ 日報</h2>
+    <div class="report-filter">
+        <label for="report-date">日付:</label>
+        <input type="date" id="report-date">
+    </div>
+    <ul id="daily-report-list"></ul>
+    <button id="back-to-main-from-report">メインに戻る</button>
+</section>
+

--- a/Code/header.html
+++ b/Code/header.html
@@ -1,6 +1,6 @@
 <header class="top-menu">
-    <button>管理室</button>
-    <button>日報</button>
+    <button id="management-button">管理室</button>
+    <button id="daily-report-button">日報</button>
     <button id="save-button">セーブ</button>
     <button id="load-button">ロード</button>
     <input type="file" id="load-file-input" accept="application/json" style="display:none">
@@ -9,3 +9,4 @@
         <span id="date">2025/06/29</span>
     </div>
 </header>
+

--- a/Code/index.html
+++ b/Code/index.html
@@ -17,6 +17,7 @@
             <div id="main-view-placeholder"></div>
             <div id="management-room-placeholder"></div>
             <div id="status-view-placeholder"></div>
+            <div id="daily-report-placeholder"></div>
         </main>
     </div>
 

--- a/Code/js/app-init.js
+++ b/Code/js/app-init.js
@@ -42,5 +42,6 @@ export async function setupApp() {
     await loadHTML('main-view-placeholder', 'main-view.html');
     await loadHTML('management-room-placeholder', 'management-view.html');
     await loadHTML('status-view-placeholder', 'character-status.html');
+    await loadHTML('daily-report-placeholder', 'daily-report.html');
     await initializeApp();
 }

--- a/Code/js/daily-report.js
+++ b/Code/js/daily-report.js
@@ -1,0 +1,35 @@
+import { dom } from './dom-cache.js';
+
+function filterEventsByDate(dateStr) {
+    const events = JSON.parse(localStorage.getItem('event_history') || '[]');
+    return events.filter(ev => {
+        if (!ev.timestamp) return false;
+        const d = new Date(ev.timestamp).toISOString().split('T')[0];
+        return d === dateStr;
+    });
+}
+
+export function renderDailyReport(dateStr) {
+    const target = dateStr || new Date().toISOString().split('T')[0];
+    if (!dateStr) dom.reportDateInput.value = target;
+    const events = filterEventsByDate(target);
+    dom.dailyReportList.innerHTML = '';
+    if (events.length === 0) {
+        const li = document.createElement('li');
+        li.textContent = 'イベントがありません';
+        dom.dailyReportList.appendChild(li);
+        return;
+    }
+    events.forEach(ev => {
+        const li = document.createElement('li');
+        const time = new Date(ev.timestamp).toTimeString().slice(0,5);
+        li.textContent = `[${time}] ${ev.description || ''}`;
+        dom.dailyReportList.appendChild(li);
+    });
+}
+
+export function setupDailyReport() {
+    dom.reportDateInput.addEventListener('change', () => {
+        renderDailyReport(dom.reportDateInput.value);
+    });
+}

--- a/Code/js/dom-cache.js
+++ b/Code/js/dom-cache.js
@@ -15,7 +15,8 @@ export function initDomCache() {
     // 管理室画面の要素
     dom.managementRoomView = document.getElementById('management-room');
     dom.backToMainButton = document.getElementById('back-to-main-button');
-    dom.managementButton = document.querySelector('.top-menu button:first-child');
+    dom.managementButton = document.getElementById('management-button');
+    dom.dailyReportButton = document.getElementById('daily-report-button');
     dom.saveButton = document.getElementById('save-button');
     dom.loadButton = document.getElementById('load-button');
     dom.loadFileInput = document.getElementById('load-file-input');
@@ -89,4 +90,10 @@ export function initDomCache() {
     };
     dom.statusRelations = document.getElementById('status-relations');
     dom.statusEvents = document.getElementById('status-events');
+
+    // 日報画面要素
+    dom.dailyReportView = document.getElementById('daily-report-view');
+    dom.dailyReportList = document.getElementById('daily-report-list');
+    dom.reportDateInput = document.getElementById('report-date');
+    dom.reportBackButton = document.getElementById('back-to-main-from-report');
 }

--- a/Code/js/event-listeners.js
+++ b/Code/js/event-listeners.js
@@ -1,5 +1,6 @@
 import { dom, initDomCache } from './dom-cache.js';
 import { switchView, alignAllSliderTicks } from './view-switcher.js';
+import { setupDailyReport } from './daily-report.js';
 import { calculateMbti } from './mbti-diagnosis.js';
 import { renderCharacters, renderManagementList } from './character-render.js';
 import { setupFormHandlers } from './form-handler.js';
@@ -8,8 +9,12 @@ import { exportState, importStateFromFile } from './storage.js';
 
 export function setupEventListeners() {
     dom.managementButton.addEventListener('click', () => switchView('management'));
+    dom.dailyReportButton.addEventListener('click', () => {
+        switchView('daily-report');
+    });
     dom.backToMainButton.addEventListener('click', () => switchView('main'));
     dom.statusBackButton.addEventListener('click', () => switchView('main'));
+    dom.reportBackButton.addEventListener('click', () => switchView('main'));
     dom.saveButton.addEventListener('click', () => exportState(state));
     dom.loadButton.addEventListener('click', () => dom.loadFileInput.click());
     dom.loadFileInput.addEventListener('change', (e) => {
@@ -67,4 +72,5 @@ export function setupEventListeners() {
     });
 
     setupFormHandlers();
+    setupDailyReport();
 }

--- a/Code/js/view-switcher.js
+++ b/Code/js/view-switcher.js
@@ -1,11 +1,13 @@
 import { dom } from './dom-cache.js';
 import { state } from './state.js';
 import { renderManagementList } from './character-render.js';
+import { renderDailyReport } from './daily-report.js';
 
 export function switchView(viewToShow) {
     if (viewToShow === 'management') {
         dom.mainViewSections.forEach(section => section.style.display = 'none');
         dom.statusView.style.display = 'none';
+        dom.dailyReportView.style.display = 'none';
         dom.managementRoomView.style.display = 'block';
         requestAnimationFrame(alignAllSliderTicks);
         renderManagementList();
@@ -13,10 +15,18 @@ export function switchView(viewToShow) {
     } else if (viewToShow === 'status') {
         dom.mainViewSections.forEach(section => section.style.display = 'none');
         dom.managementRoomView.style.display = 'none';
+        dom.dailyReportView.style.display = 'none';
         dom.statusView.style.display = 'block';
+    } else if (viewToShow === 'daily-report') {
+        dom.mainViewSections.forEach(section => section.style.display = 'none');
+        dom.managementRoomView.style.display = 'none';
+        dom.statusView.style.display = 'none';
+        dom.dailyReportView.style.display = 'block';
+        renderDailyReport();
     } else {
         dom.managementRoomView.style.display = 'none';
         dom.statusView.style.display = 'none';
+        dom.dailyReportView.style.display = 'none';
         dom.mainViewSections.forEach(section => section.style.display = 'block');
         resetFormState();
     }


### PR DESCRIPTION
## Summary
- correct CSS comment for daily report styles
- call report rendering when switching to daily report view
- simplify daily report button handler
- add trailing newlines to some files

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6871627c8c7c83338e5a1ac4cd514894