### PR TITLE
Add event log functionality

### DIFF
--- a/Code/js/app-init.js
+++ b/Code/js/app-init.js
@@ -4,6 +4,7 @@ import { renderCharacters } from './character-render.js';
 import { switchView, alignAllSliderTicks } from './view-switcher.js';
 import { loadState } from './storage.js';
 import { state } from './state.js';
+import { renderLogs } from './event-log.js';
 
 function updateDateTime() {
     const now = new Date();
@@ -33,6 +34,7 @@ export async function initializeApp() {
     setInterval(updateDateTime, 1000);
     updateDateTime();
     renderCharacters();
+    renderLogs();
     switchView('main');
     requestAnimationFrame(alignAllSliderTicks);
 }

--- a/Code/js/dom-cache.js
+++ b/Code/js/dom-cache.js
@@ -6,6 +6,8 @@ export function initDomCache() {
     dom.timeElement = document.getElementById('time');
     dom.dateElement = document.getElementById('date');
     dom.characterListElement = document.querySelector('.character-list');
+    dom.consultationArea = document.querySelector('.consultation-area');
+    dom.logContent = document.querySelector('.log-display .log-content');
     dom.mbtiInputs = {};
     for (let i = 1; i <= 16; i++) {
         dom.mbtiInputs[`q${i}`] = document.getElementById(`mbti-q${i}`);

--- a/Code/js/event-listeners.js
+++ b/Code/js/event-listeners.js
@@ -6,6 +6,7 @@ import { renderCharacters, renderManagementList } from './character-render.js';
 import { setupFormHandlers } from './form-handler.js';
 import { state, mbtiDescriptions } from './state.js';
 import { exportState, importStateFromFile } from './storage.js';
+import { addLog } from './event-log.js';
 
 export function setupEventListeners() {
     dom.managementButton.addEventListener('click', () => switchView('management'));
@@ -70,6 +71,17 @@ export function setupEventListeners() {
         dom.mbtiDiagModeBtn.classList.remove('active');
         dom.mbtiManualModeBtn.classList.add('active');
     });
+
+    if (dom.consultationArea) {
+        dom.consultationArea.addEventListener('click', (e) => {
+            if (e.target.tagName === 'BUTTON' && e.target.closest('.consultation-item')) {
+                const msg = e.target.closest('.consultation-item').querySelector('span').textContent.replace('・', '').trim();
+                addLog(`${msg} に対応しました。`);
+            } else if (e.target.classList.contains('add-consultation')) {
+                addLog('新しい相談を受け付けました。');
+            }
+        });
+    }
 
     setupFormHandlers();
     setupDailyReport();

--- a/Code/js/event-log.js
+++ b/Code/js/event-log.js
@@ -1,0 +1,60 @@
+import { dom } from './dom-cache.js';
+
+const STORAGE_KEY = 'event_history';
+let logs = [];
+
+export function loadLogs() {
+    const data = localStorage.getItem(STORAGE_KEY);
+    if (!data) {
+        logs = [];
+        return logs;
+    }
+    try {
+        logs = JSON.parse(data);
+        if (!Array.isArray(logs)) logs = [];
+    } catch (e) {
+        console.error('ログの読み込みに失敗しました', e);
+        logs = [];
+    }
+    return logs;
+}
+
+function saveLogs() {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(logs));
+}
+
+export function addLog(description) {
+    const entry = {
+        timestamp: new Date().toISOString(),
+        description
+    };
+    logs.push(entry);
+    saveLogs();
+    renderLogs();
+}
+
+export function renderLogs() {
+    if (!dom.logContent) return;
+    if (!logs.length) {
+        loadLogs();
+    }
+    dom.logContent.innerHTML = '';
+    logs.forEach(ev => {
+        const p = document.createElement('p');
+        const timeSpan = document.createElement('span');
+        timeSpan.className = 'log-time';
+        timeSpan.textContent = '[' + new Date(ev.timestamp).toTimeString().slice(0,5) + ']';
+        const eventSpan = document.createElement('span');
+        eventSpan.className = 'log-event';
+        eventSpan.textContent = 'EVENT:';
+        p.appendChild(timeSpan);
+        p.append(' ');
+        p.appendChild(eventSpan);
+        p.append(' ' + (ev.description || ''));
+        dom.logContent.appendChild(p);
+    });
+    dom.logContent.scrollTop = dom.logContent.scrollHeight;
+}
+
+// 初期読み込み
+loadLogs();

--- a/Code/js/form-handler.js
+++ b/Code/js/form-handler.js
@@ -5,6 +5,7 @@ import { renderCharacters, renderManagementList } from './character-render.js';
 import { renderRelationshipEditor } from './relationship-editor.js';
 import { switchView, resetFormState, alignAllSliderTicks } from './view-switcher.js';
 import { saveState } from './storage.js';
+import { addLog } from './event-log.js';
 
 export function setupFormHandlers() {
     dom.addCharacterForm.addEventListener('submit', (event) => {
@@ -49,6 +50,7 @@ export function setupFormHandlers() {
                 charToUpdate.activityPattern = activityPatternValue;
                 charToUpdate.interests = interestsValue;
             }
+            addLog(`キャラクター「${dom.charNameInput.value}」を更新しました。`);
             state.relationships = state.relationships.filter(r => !r.pair.includes(characterId));
             state.nicknames = state.nicknames.filter(n => n.from !== characterId && n.to !== characterId);
             state.affections = state.affections.filter(a => a.from !== characterId && a.to !== characterId);
@@ -64,6 +66,7 @@ export function setupFormHandlers() {
                 activityPattern: activityPatternValue,
                 interests: interestsValue,
             });
+            addLog(`キャラクター「${dom.charNameInput.value}」を追加しました。`);
         }
 
         Object.keys(state.tempRelations).forEach(targetId => {
@@ -110,10 +113,12 @@ export function setupFormHandlers() {
         if (event.target.classList.contains('delete-button')) {
             const idToDelete = event.target.dataset.id;
             if (confirm('本当にこのキャラクターを削除しますか？')) {
+                const target = state.characters.find(char => char.id === idToDelete);
                 state.characters = state.characters.filter(char => char.id !== idToDelete);
                 renderManagementList();
                 renderCharacters();
                 saveState(state);
+                addLog(`キャラクター「${target ? target.name : idToDelete}」を削除しました。`);
             }
         } else if (event.target.classList.contains('edit-button')) {
             const idToEdit = event.target.dataset.id;

--- a/Code/main-view.html
+++ b/Code/main-view.html
@@ -18,10 +18,5 @@
 
 <section class="log-display">
     <h2>▼ ログ表示エリア (CLI風)</h2>
-    <div class="log-content">
-        <p><span class="log-time">[08:42]</span> <span class="log-event">EVENT:</span> 莉音と咲が会話中.....</p>
-        <p class="log-dialogue">莉音「ねぇ、あの本、読んだ？」</p>
-        <p class="log-dialogue">咲「えっ、まだだけど、面白かった？」</p>
-        <p><span class="log-time">[08:45]</span> <span class="log-system">SYSTEM:</span> 信頼度が上昇しました。</p>
-    </div>
+    <div class="log-content"></div>
 </section>


### PR DESCRIPTION
## Summary
- implement `event-log.js` to store logs in `localStorage`
- cache log DOM elements and consultation area
- write logs from character management events
- log consultation actions in event listeners
- show stored logs at startup
- clean example log HTML

## Testing
- `node --check Code/js/event-log.js`
- `node --check Code/js/app-init.js`
- `node --check Code/js/dom-cache.js`
- `node --check Code/js/event-listeners.js`
- `node --check Code/js/form-handler.js`

------
https://chatgpt.com/codex/tasks/task_e_6873a406b794833380729567be7a0a2f