### PR TITLE
非介入型イベントを抽選式に変更

### DIFF
--- a/Code/js/app-init.js
+++ b/Code/js/app-init.js
@@ -6,6 +6,9 @@ import { switchView, alignAllSliderTicks } from './view-switcher.js';
 import { loadState } from './storage.js';
 import { state } from './state.js';
 
+const EVENT_INTERVAL_MS = 1800000; // 30分に1回
+const EVENT_PROBABILITY = 0.7; // 70%
+
 function updateDateTime() {
     const now = new Date();
     const hours = String(now.getHours()).padStart(2, '0');
@@ -16,6 +19,14 @@ function updateDateTime() {
     const month = String(now.getMonth() + 1).padStart(2, '0');
     const day = String(now.getDate()).padStart(2, '0');
     dom.dateElement.textContent = `${year}/${month}/${day}`;
+}
+
+function startEventScheduler() {
+    setInterval(() => {
+        if (Math.random() < EVENT_PROBABILITY) {
+            triggerRandomEvent();
+        }
+    }, EVENT_INTERVAL_MS);
 }
 
 export async function loadHTML(id, file) {
@@ -33,7 +44,7 @@ export async function initializeApp() {
     setupEventListeners();
     setInterval(updateDateTime, 1000);
     updateDateTime();
-    setInterval(triggerRandomEvent, 60000);
+    startEventScheduler();
     renderCharacters();
     switchView('main');
     requestAnimationFrame(alignAllSliderTicks);

--- a/Code/js/event-system.js
+++ b/Code/js/event-system.js
@@ -21,10 +21,11 @@ function updateAffection(from, to, delta) {
     rec.score += delta;
 }
 
-function appendLog(text) {
-    const time = new Date().toTimeString().slice(0,5);
+function appendLog(text, type = 'EVENT') {
+    const time = new Date().toTimeString().slice(0, 5);
     const p = document.createElement('p');
-    p.innerHTML = `<span class="log-time">[${time}]</span> <span class="log-event">EVENT:</span> ${text}`;
+    const cls = type === 'SYSTEM' ? 'log-system' : 'log-event';
+    p.innerHTML = `<span class="log-time">[${time}]</span> <span class="${cls}">${type}:</span> ${text}`;
     if (dom.logContent) {
         dom.logContent.appendChild(p);
         dom.logContent.scrollTop = dom.logContent.scrollHeight;
@@ -62,6 +63,8 @@ export function triggerRandomEvent() {
     updateAffection(a.id, b.id, delta);
     updateAffection(b.id, a.id, delta);
     appendLog(desc);
+    appendLog(`${a.name}→${b.name}の好感度が上昇しました`, 'SYSTEM');
+    appendLog(`${b.name}→${a.name}の好感度が上昇しました`, 'SYSTEM');
     storeEvent(desc);
     saveState(state);
 }


### PR DESCRIPTION
## Summary
- 非介入型イベントの抽選スケジュールを実装
- 好感度変化をシステムログとして出力
- `appendLog` を EVENT/SYSTEM 兼用に改良

## Testing
- `node --check Code/js/app-init.js`
- `node --check Code/js/event-system.js`


------
https://chatgpt.com/codex/tasks/task_e_6874f3cb536c833382492743a722c713