### PR TITLE
Implement mood selection on events

### DIFF
--- a/Code/js/app-init.js
+++ b/Code/js/app-init.js
@@ -2,6 +2,7 @@ import { initDomCache, dom } from './dom-cache.js';
 import { setupEventListeners } from './event-listeners.js';
 import { renderCharacters } from './character-render.js';
 import { triggerRandomEvent } from './event-system.js';
+import { loadMoodTables } from './mood.js';
 import { switchView, alignAllSliderTicks } from './view-switcher.js';
 import { loadState } from './storage.js';
 import { state } from './state.js';
@@ -41,6 +42,7 @@ export async function initializeApp() {
     if (saved) {
         Object.assign(state, saved);
     }
+    await loadMoodTables();
     setupEventListeners();
     setInterval(updateDateTime, 1000);
     updateDateTime();

--- a/Code/js/event-system.js
+++ b/Code/js/event-system.js
@@ -1,6 +1,7 @@
 import { state } from './state.js';
 import { saveState } from './storage.js';
 import { dom } from './dom-cache.js';
+import { drawMood } from './mood.js';
 
 function getRandomPair() {
     if (state.characters.length < 2) return null;
@@ -32,9 +33,9 @@ function appendLog(text, type = 'EVENT') {
     }
 }
 
-function storeEvent(text) {
+function storeEvent(event) {
     const history = JSON.parse(localStorage.getItem('event_history') || '[]');
-    history.push({ timestamp: Date.now(), description: text });
+    history.push(event);
     localStorage.setItem('event_history', JSON.stringify(history));
 }
 
@@ -62,9 +63,10 @@ export function triggerRandomEvent() {
     }
     updateAffection(a.id, b.id, delta);
     updateAffection(b.id, a.id, delta);
+    const mood = drawMood(a.id, b.id);
     appendLog(desc);
     appendLog(`${a.name}→${b.name}の好感度が上昇しました`, 'SYSTEM');
     appendLog(`${b.name}→${a.name}の好感度が上昇しました`, 'SYSTEM');
-    storeEvent(desc);
+    storeEvent({ timestamp: Date.now(), description: desc, mood });
     saveState(state);
 }

--- a/Code/js/mood.js
+++ b/Code/js/mood.js
@@ -1,0 +1,78 @@
+// 雰囲気(mood)抽選関連の処理
+import { state } from './state.js';
+
+let initialDistribution = {};
+let relationModifier = {};
+let emotionModifier = {};
+
+export async function loadMoodTables() {
+    const [distRes, relRes, emoRes] = await Promise.all([
+        fetch('../data/initial_distribution_table.json'),
+        fetch('../data/relation_modifier_table.json'),
+        fetch('../data/emotion_modifier_table.json'),
+    ]);
+    initialDistribution = await distRes.json();
+    relationModifier = await relRes.json();
+    emotionModifier = await emoRes.json();
+}
+
+function getAffection(from, to) {
+    return state.affections.find(a => a.from === from && a.to === to)?.score || 0;
+}
+
+function getRelationLabel(idA, idB) {
+    const pair = [idA, idB].sort();
+    const rel = state.relationships.find(r => r.pair[0] === pair[0] && r.pair[1] === pair[1]);
+    return rel ? rel.label : '友達'; // デフォルトは友達相当
+}
+
+function getModifier(table, label) {
+    return table[label] || table['友達'] || { '-2': 1, '-1': 1, '0': 1, '1': 1, '2': 1 };
+}
+
+export function drawMood(idA, idB) {
+    const affAtoB = getAffection(idA, idB);
+    const affBtoA = getAffection(idB, idA);
+    const affectionAvg = Math.round((affAtoB + affBtoA) / 2);
+
+    let baseMood = 0;
+    if (affectionAvg <= -30) {
+        baseMood = -2;
+    } else if (affectionAvg < 0) {
+        baseMood = -1;
+    } else if (affectionAvg <= 30) {
+        baseMood = 0;
+    } else if (affectionAvg <= 60) {
+        baseMood = 1;
+    } else {
+        baseMood = 2;
+    }
+
+    const base = initialDistribution[String(baseMood)];
+    if (!base) return 0;
+
+    const relationCoeff = getModifier(relationModifier, getRelationLabel(idA, idB));
+    // 感情ラベルは未実装のため仮に 'なし' を使用
+    const emotionCoeffA = getModifier(emotionModifier, 'なし');
+    const emotionCoeffB = getModifier(emotionModifier, 'なし');
+
+    const corrected = {};
+    let total = 0;
+    for (let m = -2; m <= 2; m++) {
+        const key = String(m);
+        const weight = (base[key] || 0)
+            * (relationCoeff[key] || 1)
+            * (emotionCoeffA[key] || 1)
+            * (emotionCoeffB[key] || 1);
+        corrected[key] = weight;
+        total += weight;
+    }
+
+    if (total <= 0) return 0;
+    let rnd = Math.random() * total;
+    for (let m = -2; m <= 2; m++) {
+        rnd -= corrected[String(m)];
+        if (rnd < 0) return m;
+    }
+    return 0;
+}

--- a/Code/js/mood.js
+++ b/Code/js/mood.js
@@ -7,9 +7,9 @@ let emotionModifier = {};
 
 export async function loadMoodTables() {
     const [distRes, relRes, emoRes] = await Promise.all([
-        fetch('../data/initial_distribution_table.json'),
-        fetch('../data/relation_modifier_table.json'),
-        fetch('../data/emotion_modifier_table.json'),
+        fetch('./data/initial_distribution_table.json'),
+        fetch('./data/relation_modifier_table.json'),
+        fetch('./data/emotion_modifier_table.json'),
     ]);
     initialDistribution = await distRes.json();
     relationModifier = await relRes.json();


### PR DESCRIPTION
## Summary
- add new module to compute event mood
- store mood in event history
- load mood tables during app initialization
- integrate mood drawing in random event generation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874f995cc648333ad9cff907a3458c4