### PR TITLE
雰囲気による好感度補正を追加

### DIFF
--- a/Code/js/event-system.js
+++ b/Code/js/event-system.js
@@ -3,6 +3,23 @@ import { saveState } from './storage.js';
 import { dom } from './dom-cache.js';
 import { drawMood } from './mood.js';
 
+// イベント種別ごとの基礎好感度値
+const baseAffection = {
+    '挨拶': 1,
+    '雑談': 2,
+    '思い出し会話': 3,
+    '二人きりの時間': 4,
+};
+
+// 雰囲気値による好感度補正値
+const moodAffectionModifier = {
+    2: 3,    // very_positive
+    1: 2,    // positive
+    0: 0,    // neutral
+    '-1': -3,   // negative
+    '-2': -5    // very_negative
+};
+
 function getRandomPair() {
     if (state.characters.length < 2) return null;
     const idx1 = Math.floor(Math.random() * state.characters.length);
@@ -20,6 +37,8 @@ function updateAffection(from, to, delta) {
         state.affections.push(rec);
     }
     rec.score += delta;
+    // 好感度は -100 〜 +100 に制限
+    rec.score = Math.max(-100, Math.min(100, rec.score));
 }
 
 function appendLog(text, type = 'EVENT') {
@@ -43,30 +62,41 @@ export function triggerRandomEvent() {
     const pair = getRandomPair();
     if (!pair) return;
     const [a, b] = pair;
-    const types = ['雑談', '思い出し会話', '二人きりの時間'];
+    const types = ['挨拶', '雑談', '思い出し会話', '二人きりの時間'];
     const type = types[Math.floor(Math.random() * types.length)];
     let desc = '';
-    let delta = 0;
     switch (type) {
+        case '挨拶':
+            desc = `${a.name}と${b.name}が軽く挨拶を交わした。`;
+            break;
         case '雑談':
             desc = `${a.name}と${b.name}が楽しそうに雑談している。`;
-            delta = 1;
             break;
         case '思い出し会話':
             desc = `${a.name}と${b.name}が昔の出来事を思い出して語り合っている。`;
-            delta = 2;
             break;
         case '二人きりの時間':
             desc = `${a.name}と${b.name}が静かに二人きりの時間を過ごしている。`;
-            delta = 3;
             break;
     }
+
+    // 雰囲気を決定し、好感度変化量を算出
+    const mood = drawMood(a.id, b.id);
+    const base = baseAffection[type] || 0;
+    const delta = base + (moodAffectionModifier[mood] || 0);
+
     updateAffection(a.id, b.id, delta);
     updateAffection(b.id, a.id, delta);
-    const mood = drawMood(a.id, b.id);
+
     appendLog(desc);
-    appendLog(`${a.name}→${b.name}の好感度が上昇しました`, 'SYSTEM');
-    appendLog(`${b.name}→${a.name}の好感度が上昇しました`, 'SYSTEM');
+    if (delta !== 0) {
+        const verb = delta > 0 ? '上昇しました' : '下降しました';
+        appendLog(`${a.name}→${b.name}の好感度が${verb}`, 'SYSTEM');
+        appendLog(`${b.name}→${a.name}の好感度が${verb}`, 'SYSTEM');
+    } else {
+        appendLog(`${a.name}と${b.name}の好感度に変化はありません`, 'SYSTEM');
+    }
+
     storeEvent({ timestamp: Date.now(), description: desc, mood });
     saveState(state);
 }


### PR DESCRIPTION
## Summary
- イベント種別ごとの基礎好感度値を定義
- 雰囲気値に応じた好感度補正テーブルを追加
- `updateAffection` で値を -100～100 に制限
- ランダムイベント発生時に雰囲気と基礎値から最終変化量を算出
- 挨拶イベントを新規追加し、ログ表示も変化量に対応

## Testing
- `node -e "require('./Code/js/event-system.js'); console.log('ok');"`

------
https://chatgpt.com/codex/tasks/task_e_687524fbb7b88333bcbc637d4d3a3261