### PR TITLE
キャラクター管理画面の情報拡充

### DIFF
--- a/Code/character-status.html
+++ b/Code/character-status.html
@@ -7,6 +7,8 @@
         <p>一人称: <span id="status-first-person"></span></p>
         <p>語尾: <span id="status-suffix"></span></p>
         <p>現在状態: <span id="status-condition"></span></p>
+        <p>活動傾向: <span id="status-activity-pattern"></span></p>
+        <p>信頼度: <span id="status-trust"></span></p>
     </div>
     <h3>▼ 性格パラメータ</h3>
     <ul class="personality-list">

--- a/Code/css/components.css
+++ b/Code/css/components.css
@@ -118,6 +118,14 @@ input[type="range"]::-moz-range-thumb {
     font-weight: bold;
     color: #ffd166;
 }
+.relation-item summary {
+    cursor: pointer;
+    list-style: none;
+}
+.detail-body {
+    margin-left: 1em;
+    margin-top: 4px;
+}
 .relation-direction {
     margin-left: 1em;
     margin-top: 4px;

--- a/Code/js/character-render.js
+++ b/Code/js/character-render.js
@@ -1,5 +1,6 @@
 import { dom } from './dom-cache.js';
 import { state } from './state.js';
+import { getEmotionLabel } from './emotion-label.js';
 import { switchView } from './view-switcher.js';
 
 export function renderCharacters() {
@@ -86,6 +87,9 @@ function showCharacterStatus(char) {
     dom.statusFirstPerson.textContent = style.first_person;
     dom.statusSuffix.textContent = style.suffix;
     dom.statusCondition.textContent = '活動中';
+    dom.statusActivityPattern.textContent = char.activityPattern || '不明';
+    const trustRec = state.trusts.find(t => t.id === char.id);
+    dom.statusTrust.textContent = trustRec ? trustRec.score : 50;
     const p = char.personality;
     dom.statusPersonality.social.textContent = levelToBars(p.social);
     dom.statusPersonality.kindness.textContent = levelToBars(p.kindness);
@@ -93,16 +97,18 @@ function showCharacterStatus(char) {
     dom.statusPersonality.activity.textContent = levelToBars(p.activity);
     dom.statusPersonality.expressiveness.textContent = levelToBars(p.expressiveness);
 
-    const relations = state.relationships
-        .filter(r => r.pair.includes(char.id))
-        .map(rel => {
-            const otherId = rel.pair.find(id => id !== char.id);
-            const other = state.characters.find(c => c.id === otherId);
-            const affectionTo = state.affections.find(a => a.from === char.id && a.to === otherId)?.score || 0;
-            const affectionFrom = state.affections.find(a => a.from === otherId && a.to === char.id)?.score || 0;
-            const nicknameTo = state.nicknames.find(n => n.from === char.id && n.to === otherId)?.nickname || '';
-            const nicknameFrom = state.nicknames.find(n => n.from === otherId && n.to === char.id)?.nickname || '';
-            return { otherId, other, label: rel.label, affectionTo, affectionFrom, nicknameTo, nicknameFrom };
+    const relations = state.characters
+        .filter(c => c.id !== char.id)
+        .map(other => {
+            const pair = [char.id, other.id].sort();
+            const relRec = state.relationships.find(r => r.pair[0] === pair[0] && r.pair[1] === pair[1]);
+            const label = relRec ? relRec.label : 'なし';
+            const affectionTo = state.affections.find(a => a.from === char.id && a.to === other.id)?.score || 0;
+            const affectionFrom = state.affections.find(a => a.from === other.id && a.to === char.id)?.score || 0;
+            const nicknameTo = state.nicknames.find(n => n.from === char.id && n.to === other.id)?.nickname || '';
+            const nicknameFrom = state.nicknames.find(n => n.from === other.id && n.to === char.id)?.nickname || '';
+            const emotion = getEmotionLabel(char.id, other.id) || 'なし';
+            return { other, label, affectionTo, affectionFrom, nicknameTo, nicknameFrom, emotion };
         })
         .sort((a, b) => (b.affectionTo + b.affectionFrom) - (a.affectionTo + a.affectionFrom));
 
@@ -113,18 +119,22 @@ function showCharacterStatus(char) {
         dom.statusRelations.appendChild(li);
     } else {
         relations.forEach(rel => {
-            const otherName = rel.other ? rel.other.name : rel.otherId;
+            const otherName = rel.other.name;
             const li = document.createElement('li');
             li.className = 'relation-item';
 
-            const header = document.createElement('p');
-            header.className = 'relation-header';
-            header.innerHTML = `■ 相手：<span class="other-name">${otherName}</span>（関係：${rel.label}）`;
-            li.appendChild(header);
+            const details = document.createElement('details');
+            const summary = document.createElement('summary');
+            summary.innerHTML = `<span class="other-name">${otherName}</span> - ${rel.label} | 印象: ${rel.emotion}`;
+            details.appendChild(summary);
 
-            li.appendChild(createDirectionBlock(`${char.name} → ${otherName}`, rel.affectionTo, rel.nicknameTo));
-            li.appendChild(createDirectionBlock(`${otherName} → ${char.name}`, rel.affectionFrom, rel.nicknameFrom));
+            const body = document.createElement('div');
+            body.className = 'detail-body';
+            body.appendChild(createDirectionBlock(`${char.name} → ${otherName}`, rel.affectionTo, rel.nicknameTo));
+            body.appendChild(createDirectionBlock(`${otherName} → ${char.name}`, rel.affectionFrom, rel.nicknameFrom));
+            details.appendChild(body);
 
+            li.appendChild(details);
             dom.statusRelations.appendChild(li);
         });
     }

--- a/Code/js/dom-cache.js
+++ b/Code/js/dom-cache.js
@@ -90,6 +90,8 @@ export function initDomCache() {
     dom.statusFirstPerson = document.getElementById('status-first-person');
     dom.statusSuffix = document.getElementById('status-suffix');
     dom.statusCondition = document.getElementById('status-condition');
+    dom.statusActivityPattern = document.getElementById('status-activity-pattern');
+    dom.statusTrust = document.getElementById('status-trust');
     dom.statusPersonality = {
         social: document.getElementById('status-social'),
         kindness: document.getElementById('status-kindness'),


### PR DESCRIPTION
## Summary
- ステータス画面に活動傾向とプレイヤーへの信頼度を追加
- 関係一覧を `details` 要素で簡潔に表示し、クリックで詳細を展開
- 関係レコードが無い相手も一覧に表示するように変更
- UI 調整のため CSS を追加

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877b659bcb08333a7acd6a9456fb75f