### PR TITLE
Add logs and reports persistence

### DIFF
--- a/Code/js/app-init.js
+++ b/Code/js/app-init.js
@@ -7,6 +7,7 @@ import { loadEmotionLabelTable } from './emotion-label.js';
 import { switchView, alignAllSliderTicks } from './view-switcher.js';
 import { loadState } from './storage.js';
 import { state } from './state.js';
+import { renderSavedLogs } from './logger.js';
 import { loadConsultationTemplates, startConsultationScheduler, renderConsultations } from './consultation.js';
 
 const EVENT_INTERVAL_MS = 1800000; // 30分に1回
@@ -43,6 +44,7 @@ export async function initializeApp() {
     const saved = loadState();
     if (saved) {
         Object.assign(state, saved);
+        renderSavedLogs();
     }
     await loadEmotionLabelTable();
     await loadMoodTables();

--- a/Code/js/character-render.js
+++ b/Code/js/character-render.js
@@ -80,8 +80,7 @@ function createDirectionBlock(labelText, score, nickname) {
 }
 
 function renderCharacterEvents(char) {
-    const all = JSON.parse(localStorage.getItem('event_history') || '[]');
-    const events = all
+    const events = state.reports
         .filter(ev => ev.description && ev.description.includes(char.name))
         .sort((a, b) => b.timestamp - a.timestamp)
         .slice(0, 5);

--- a/Code/js/daily-report.js
+++ b/Code/js/daily-report.js
@@ -1,8 +1,8 @@
 import { dom } from './dom-cache.js';
+import { state } from './state.js';
 
 function filterEventsByDate(dateStr) {
-    const events = JSON.parse(localStorage.getItem('event_history') || '[]');
-    return events.filter(ev => {
+    return state.reports.filter(ev => {
         if (!ev.timestamp) return false;
         const d = new Date(ev.timestamp).toISOString().split('T')[0];
         return d === dateStr;

--- a/Code/js/event-listeners.js
+++ b/Code/js/event-listeners.js
@@ -8,6 +8,7 @@ import { state, mbtiDescriptions } from './state.js';
 import { exportState, importStateFromFile } from './storage.js';
 import { triggerRandomEvent } from './event-system.js';
 import { createConsultation, setupConsultationHandlers } from './consultation.js';
+import { renderSavedLogs } from './logger.js';
 
 export function setupEventListeners() {
     dom.managementButton.addEventListener('click', () => switchView('management'));
@@ -28,6 +29,7 @@ export function setupEventListeners() {
                 Object.assign(state, loaded);
                 renderCharacters();
                 renderManagementList();
+                renderSavedLogs();
             })
             .catch(() => alert('読み込みに失敗しました。'))
             .finally(() => {

--- a/Code/js/event-system.js
+++ b/Code/js/event-system.js
@@ -44,9 +44,7 @@ function updateAffection(from, to, delta) {
 
 
 function storeEvent(event) {
-    const history = JSON.parse(localStorage.getItem('event_history') || '[]');
-    history.push(event);
-    localStorage.setItem('event_history', JSON.stringify(history));
+    state.reports.push(event);
 }
 
 export function triggerRandomEvent() {

--- a/Code/js/logger.js
+++ b/Code/js/logger.js
@@ -1,7 +1,30 @@
 import { dom } from './dom-cache.js';
+import { state } from './state.js';
+
+export function renderSavedLogs() {
+    const logArea = dom.logContent;
+    if (!logArea) return;
+    logArea.innerHTML = '';
+    const dates = Object.keys(state.logs).sort();
+    dates.forEach(date => {
+        state.logs[date].forEach(entry => {
+            const p = document.createElement('p');
+            const cls = entry.type === 'SYSTEM' ? 'log-system' : 'log-event';
+            p.innerHTML = `<span class="log-time">[${entry.time}]</span> <span class="${cls}">${entry.type}:</span> ${entry.text}`;
+            logArea.appendChild(p);
+        });
+    });
+    logArea.scrollTop = logArea.scrollHeight;
+}
 
 export function appendLog(text, type = 'EVENT') {
-    const time = new Date().toTimeString().slice(0, 5);
+    const now = new Date();
+    const time = now.toTimeString().slice(0, 5);
+    const dateKey = now.toISOString().split('T')[0];
+    if (!state.logs[dateKey]) {
+        state.logs[dateKey] = [];
+    }
+    state.logs[dateKey].push({ time, type, text });
     const p = document.createElement('p');
     const cls = type === 'SYSTEM' ? 'log-system' : 'log-event';
     p.innerHTML = `<span class="log-time">[${time}]</span> <span class="${cls}">${type}:</span> ${text}`;

--- a/Code/js/state.js
+++ b/Code/js/state.js
@@ -50,6 +50,8 @@ export let state = {
         { id: 'char_003', score: 50 }
     ], // プレイヤーへの信頼度
     consultations: [], // 進行中の相談イベント
+    logs: {}, // CLIログを日付ごとに保存
+    reports: [], // 日報イベント履歴を保存
     currentlyEditingId: null,
     tempRelations: {},
 };

--- a/Code/js/storage.js
+++ b/Code/js/storage.js
@@ -2,7 +2,12 @@ const STORAGE_KEY = 'relation_sim_state';
 
 export function saveState(state) {
     try {
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+        const data = {
+            ...state,
+            logs: state.logs,
+            reports: state.reports,
+        };
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
     } catch (e) {
         console.error('状態の保存に失敗しました', e);
     }
@@ -12,7 +17,10 @@ export function loadState() {
     const data = localStorage.getItem(STORAGE_KEY);
     if (!data) return null;
     try {
-        return JSON.parse(data);
+        const parsed = JSON.parse(data);
+        parsed.logs = parsed.logs || {};
+        parsed.reports = parsed.reports || [];
+        return parsed;
     } catch (e) {
         console.error('保存データの読み込みに失敗しました', e);
         return null;
@@ -20,7 +28,12 @@ export function loadState() {
 }
 
 export function exportState(state) {
-    const blob = new Blob([JSON.stringify(state, null, 2)], { type: 'application/json' });
+    const data = {
+        ...state,
+        logs: state.logs,
+        reports: state.reports,
+    };
+    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
@@ -37,6 +50,8 @@ export function importStateFromFile(file) {
         reader.onload = () => {
             try {
                 const data = JSON.parse(reader.result);
+                data.logs = data.logs || {};
+                data.reports = data.reports || [];
                 resolve(data);
             } catch (e) {
                 reject(e);


### PR DESCRIPTION
## Summary
- expand global state with `logs` and `reports`
- save/restore log information when exporting or importing data
- keep event history in `state.reports`
- store CLI logs in `state.logs` and re-render after loading

## Testing
- `node -e "require('./Code/js/state.js');"`
- `node -e "require('./Code/js/logger.js');"`
- `node -e "require('./Code/js/storage.js');"`
- `node -e "require('./Code/js/event-system.js');"`
- `node -e "require('./Code/js/daily-report.js');"`
- `node -e "require('./Code/js/character-render.js');"`
- `node -e "require('./Code/js/event-listeners.js');"`
- `node -e "require('./Code/js/app-init.js');"`


------
https://chatgpt.com/codex/tasks/task_e_6877c65fd24c833383c6dff36479cf7e