### PR TITLE
日報に変化履歴を表示

### DIFF
--- a/Code/css/components.css
+++ b/Code/css/components.css
@@ -310,6 +310,12 @@ input[type="range"]::-moz-range-thumb {
     padding-left: 0;
 }
 
+#change-history-list {
+    list-style: none;
+    padding-left: 0;
+    margin-top: 10px;
+}
+
 #daily-report-view input[type="date"] {
     color: #e0e0e0;
     background-color: #3d3d3d;

--- a/Code/daily-report.html
+++ b/Code/daily-report.html
@@ -4,7 +4,10 @@
         <label for="report-date">日付:</label>
         <input type="date" id="report-date">
     </div>
+    <h3>発生イベント</h3>
     <ul id="daily-report-list"></ul>
+    <h3>変化履歴</h3>
+    <ul id="change-history-list"></ul>
     <button id="back-to-main-from-report">メインに戻る</button>
 </section>
 

--- a/Code/js/character-render.js
+++ b/Code/js/character-render.js
@@ -80,7 +80,8 @@ function createDirectionBlock(labelText, score, nickname) {
 }
 
 function renderCharacterEvents(char) {
-    const events = state.reports
+    const events = Object.values(state.reports)
+        .flatMap(r => r.events)
         .filter(ev => ev.description && ev.description.includes(char.name))
         .sort((a, b) => b.timestamp - a.timestamp)
         .slice(0, 5);

--- a/Code/js/daily-report.js
+++ b/Code/js/daily-report.js
@@ -1,31 +1,41 @@
 import { dom } from './dom-cache.js';
 import { state } from './state.js';
 
-function filterEventsByDate(dateStr) {
-    return state.reports.filter(ev => {
-        if (!ev.timestamp) return false;
-        const d = new Date(ev.timestamp).toISOString().split('T')[0];
-        return d === dateStr;
-    });
+function getReportByDate(dateStr) {
+    const report = state.reports[dateStr];
+    if (!report) return { events: [], changes: [] };
+    return report;
 }
 
 export function renderDailyReport(dateStr) {
     const target = dateStr || new Date().toISOString().split('T')[0];
     if (!dateStr) dom.reportDateInput.value = target;
-    const events = filterEventsByDate(target);
+    const report = getReportByDate(target);
     dom.dailyReportList.innerHTML = '';
-    if (events.length === 0) {
+    dom.changeHistoryList.innerHTML = '';
+    if (report.events.length === 0) {
         const li = document.createElement('li');
         li.textContent = 'イベントがありません';
         dom.dailyReportList.appendChild(li);
-        return;
+    } else {
+        report.events.forEach(ev => {
+            const li = document.createElement('li');
+            const time = new Date(ev.timestamp).toTimeString().slice(0,5);
+            li.textContent = `[${time}] ${ev.description || ''}`;
+            dom.dailyReportList.appendChild(li);
+        });
     }
-    events.forEach(ev => {
+    if (report.changes.length === 0) {
         const li = document.createElement('li');
-        const time = new Date(ev.timestamp).toTimeString().slice(0,5);
-        li.textContent = `[${time}] ${ev.description || ''}`;
-        dom.dailyReportList.appendChild(li);
-    });
+        li.textContent = '変化はありません';
+        dom.changeHistoryList.appendChild(li);
+    } else {
+        report.changes.forEach(chg => {
+            const li = document.createElement('li');
+            li.textContent = `[${chg.time}] ${chg.description}`;
+            dom.changeHistoryList.appendChild(li);
+        });
+    }
 }
 
 export function setupDailyReport() {

--- a/Code/js/dom-cache.js
+++ b/Code/js/dom-cache.js
@@ -105,6 +105,7 @@ export function initDomCache() {
     // 日報画面要素
     dom.dailyReportView = document.getElementById('daily-report-view');
     dom.dailyReportList = document.getElementById('daily-report-list');
+    dom.changeHistoryList = document.getElementById('change-history-list');
     dom.reportDateInput = document.getElementById('report-date');
     dom.reportBackButton = document.getElementById('back-to-main-from-report');
 }

--- a/Code/js/emotion-label.js
+++ b/Code/js/emotion-label.js
@@ -1,5 +1,6 @@
 import { state } from './state.js';
 import { appendLog } from './logger.js';
+import { addReportChange } from './report-utils.js';
 
 let drawTable = null;
 
@@ -107,5 +108,6 @@ export function drawEmotionChange(from, to, mood) {
         const fromName = state.characters.find(c => c.id === from)?.name || from;
         const toName = state.characters.find(c => c.id === to)?.name || to;
         appendLog(`${fromName}→${toName}の印象が「${result}」に変化しました。`, 'SYSTEM');
+        addReportChange(`${fromName}→${toName}の印象「${current}」→「${result}」`);
     }
 }

--- a/Code/js/event-system.js
+++ b/Code/js/event-system.js
@@ -3,6 +3,7 @@ import { saveState } from './storage.js';
 import { drawMood } from './mood.js';
 import { appendLog } from './logger.js';
 import { drawEmotionChange } from './emotion-label.js';
+import { addReportEvent, addReportChange } from './report-utils.js';
 
 // イベント種別ごとの基礎好感度値
 const baseAffection = {
@@ -43,9 +44,6 @@ function updateAffection(from, to, delta) {
 }
 
 
-function storeEvent(event) {
-    state.reports.push(event);
-}
 
 export function triggerRandomEvent() {
     const pair = getRandomPair();
@@ -76,6 +74,11 @@ export function triggerRandomEvent() {
 
     updateAffection(a.id, b.id, delta);
     updateAffection(b.id, a.id, delta);
+    if (delta !== 0) {
+        const verb = delta > 0 ? '上昇しました' : '下降しました';
+        addReportChange(`${a.name}→${b.name}の好感度が${verb}`);
+        addReportChange(`${b.name}→${a.name}の好感度が${verb}`);
+    }
 
     appendLog(desc);
     if (delta !== 0) {
@@ -90,6 +93,6 @@ export function triggerRandomEvent() {
     drawEmotionChange(a.id, b.id, mood);
     drawEmotionChange(b.id, a.id, mood);
 
-    storeEvent({ timestamp: Date.now(), description: desc, mood });
+    addReportEvent({ timestamp: Date.now(), description: desc, mood });
     saveState(state);
 }

--- a/Code/js/report-utils.js
+++ b/Code/js/report-utils.js
@@ -1,0 +1,19 @@
+import { state } from './state.js';
+
+export function addReportEvent(event) {
+    const dateKey = new Date(event.timestamp).toISOString().split('T')[0];
+    if (!state.reports[dateKey]) {
+        state.reports[dateKey] = { events: [], changes: [] };
+    }
+    state.reports[dateKey].events.push(event);
+}
+
+export function addReportChange(description) {
+    const now = new Date();
+    const dateKey = now.toISOString().split('T')[0];
+    const time = now.toTimeString().slice(0, 5);
+    if (!state.reports[dateKey]) {
+        state.reports[dateKey] = { events: [], changes: [] };
+    }
+    state.reports[dateKey].changes.push({ time, description });
+}

--- a/Code/js/state.js
+++ b/Code/js/state.js
@@ -51,7 +51,7 @@ export let state = {
     ], // プレイヤーへの信頼度
     consultations: [], // 進行中の相談イベント
     logs: {}, // CLIログを日付ごとに保存
-    reports: [], // 日報イベント履歴を保存
+    reports: {}, // 日報イベント履歴を日付ごとに保存
     currentlyEditingId: null,
     tempRelations: {},
 };

--- a/Code/js/storage.js
+++ b/Code/js/storage.js
@@ -19,7 +19,7 @@ export function loadState() {
     try {
         const parsed = JSON.parse(data);
         parsed.logs = parsed.logs || {};
-        parsed.reports = parsed.reports || [];
+        parsed.reports = parsed.reports || {};
         return parsed;
     } catch (e) {
         console.error('保存データの読み込みに失敗しました', e);
@@ -51,7 +51,7 @@ export function importStateFromFile(file) {
             try {
                 const data = JSON.parse(reader.result);
                 data.logs = data.logs || {};
-                data.reports = data.reports || [];
+                data.reports = data.reports || {};
                 resolve(data);
             } catch (e) {
                 reject(e);


### PR DESCRIPTION
## Summary
- 日毎のイベントと変化を記録する `report-utils.js` を新規作成
- 感情ラベルや好感度が変化したとき `state.reports` に履歴を追記
- 日報画面で変化履歴を表示するよう `daily-report.js` と HTML を更新
- 対応する DOM 要素と CSS スタイルを追加
- 既存処理を新しいレポート構造に合わせて修正

## Testing
- `node -c Code/js/event-system.js`
- `node -c Code/js/emotion-label.js`
- `node -c Code/js/daily-report.js`
- `node -c Code/js/character-render.js`
- `node -c Code/js/report-utils.js`

------
https://chatgpt.com/codex/tasks/task_e_6877c9ecbd1083339a0b59799d3d64e6