### PR TITLE
Fix index.css import order

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,6 +1,6 @@
+@import '../Code/css/layout.css';
+@import '../Code/css/components.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-@import '../Code/css/layout.css';
-@import '../Code/css/components.css';


### PR DESCRIPTION
## Summary
- `client/src/index.css` で `@import` 行を `@tailwind` より前に移動

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68789e338a9c8333b7f9bcb1a42d2f02