### PR TITLE
Add consultation area component

### DIFF
--- a/client/src/components/ConsultationArea.jsx
+++ b/client/src/components/ConsultationArea.jsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react'
+
+export default function ConsultationArea({ characters }) {
+  const [consultations, setConsultations] = useState([])
+  const [current, setCurrent] = useState(null)
+  const [answer, setAnswer] = useState('')
+
+  const addConsultation = () => {
+    if (consultations.length >= 3) return
+    const char = characters[Math.floor(Math.random() * characters.length)]
+    const c = {
+      id: Date.now(),
+      char,
+      question: '相談内容の例です。どうしたらいいと思う？'
+    }
+    setConsultations(prev => [...prev, c])
+  }
+
+  const open = (c) => {
+    setCurrent(c)
+    setAnswer('')
+  }
+
+  const close = () => {
+    setCurrent(null)
+  }
+
+  const send = () => {
+    setConsultations(prev => prev.filter(item => item.id !== current.id))
+    setCurrent(null)
+  }
+
+  return (
+    <section className="consultation-area mb-4">
+      <h2 className="mb-2">▼ 困りごと相談エリア</h2>
+      <ul className="mb-2">
+        {consultations.slice(0, 3).map(c => (
+          <li key={c.id} className="consultation-item flex justify-between bg-gray-700 rounded px-2 py-1 mb-1">
+            <span>・{c.char.name}から相談があります</span>
+            <button onClick={() => open(c)}>対応する</button>
+          </li>
+        ))}
+      </ul>
+      <button className="add-consultation" onClick={addConsultation}>+ 相談をさらに受ける</button>
+
+      {current && (
+        <div className="consultation-popup fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-50">
+          <div className="popup-inner bg-gray-700 p-4 rounded relative w-11/12 max-w-sm">
+            <button className="popup-close absolute top-1 right-2" onClick={close}>×</button>
+            <p className="mb-2">{current.char.name}「{current.question}」</p>
+            <input className="text-black w-full mb-2" value={answer} onChange={e => setAnswer(e.target.value)} placeholder="ここに入力" />
+            <button onClick={send}>送信する</button>
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/client/src/components/MainView.jsx
+++ b/client/src/components/MainView.jsx
@@ -1,4 +1,11 @@
 import React from 'react'
+import ConsultationArea from './ConsultationArea.jsx'
+
+function parseLog(line) {
+  const m = line.match(/^\[(.*?)\]\s*(EVENT|SYSTEM):\s*(.*)$/)
+  if (m) return { time: m[1], type: m[2], text: m[3] }
+  return { time: '', type: 'EVENT', text: line }
+}
 
 export default function MainView({ characters, onSelect, logs }) {
   return (
@@ -13,12 +20,22 @@ export default function MainView({ characters, onSelect, logs }) {
           ))}
         </div>
       </section>
+      <ConsultationArea characters={characters} />
       <section className="log-display">
         <h2 className="mb-2">▼ ログ表示エリア (CLI風)</h2>
         <div className="log-content h-40 overflow-y-auto bg-black p-2">
-          {logs.map((line, idx) => (
-            <p key={idx}>{line}</p>
-          ))}
+          {logs.map((line, idx) => {
+            const { time, type, text } = parseLog(line)
+            const cls = type === 'SYSTEM'
+              ? 'text-orange-300 font-bold'
+              : 'text-sky-400 font-bold'
+            return (
+              <p key={idx} className="mb-1">
+                {time && <span className="text-gray-400 mr-1">[{time}]</span>}
+                <span className={cls}>{type}:</span> {text}
+              </p>
+            )
+          })}
         </div>
       </section>
     </div>


### PR DESCRIPTION
## Summary
- add `ConsultationArea` component for a simple consultation list and popup
- embed the new component in `MainView`
- color-code logs with Tailwind classes

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878a36dd7b883338a1df971ce25465f