### PR TITLE
Add consultation feature with trust handling

### DIFF
--- a/client/public/Code/data/trouble_prompt_templates.json
+++ b/client/public/Code/data/trouble_prompt_templates.json
@@ -1,0 +1,149 @@
+[
+  {
+    "id": "N-A-0-choice",
+    "genre": "日常のひとこと",
+    "level": 0,
+    "form": "choice",
+    "core_prompt": "今日は風が気持ちいいね。こういう日、なんかしたくならない？"
+  },
+  {
+    "id": "N-A-1-choice",
+    "genre": "日常のひとこと",
+    "level": 0,
+    "form": "choice",
+    "core_prompt": "なんか今日、ちょっとだけラッキーなことがあった気がするんだ"
+  },
+  {
+    "id": "N-B-0-choice",
+    "genre": "興味・楽しみ",
+    "level": 1,
+    "form": "choice",
+    "core_prompt": "最近、ちょっとだけ好きになったものがあってね"
+  },
+  {
+    "id": "N-B-1-fill",
+    "genre": "興味・楽しみ",
+    "level": 1,
+    "form": "fill",
+    "core_prompt": "最近、また〇〇にハマりはじめちゃってさ。君も似たようなことある？"
+  },
+  {
+    "id": "N-B-2-fill",
+    "genre": "興味・楽しみ",
+    "level": 1,
+    "form": "fill",
+    "core_prompt": "次の休み、ちょっとしたことをしたくて。君なら何したい？"
+  },
+  {
+    "id": "N-C-0-choice",
+    "genre": "他愛ない雑談",
+    "level": 0,
+    "form": "choice",
+    "core_prompt": "今ちょうどお茶してるんだけど、なんとなく話したくなって"
+  },
+  {
+    "id": "N-C-1-fill",
+    "genre": "他愛ない雑談",
+    "level": 0,
+    "form": "fill",
+    "core_prompt": "今ってちょうどぼんやりするのに最適な時間じゃない？…君は何してた？"
+  },
+  {
+    "id": "N-C-2-fill",
+    "genre": "他愛ない雑談",
+    "level": 0,
+    "form": "fill",
+    "core_prompt": "こういう何でもない話って、けっこう好きなんだよね。君は？"
+  },
+  {
+    "id": "N-D-0-choice",
+    "genre": "小さなつまずき",
+    "level": 1,
+    "form": "choice",
+    "core_prompt": "今日はちょっとだけサボっちゃった。こういう日ってあるよね？"
+  },
+  {
+    "id": "N-D-1-fill",
+    "genre": "小さなつまずき",
+    "level": 2,
+    "form": "fill",
+    "core_prompt": "人と比べちゃいけないって分かってても、時々しんどくなる。…君は平気？"
+  },
+  {
+    "id": "N-E-0-choice",
+    "genre": "愚痴っぽいぼやき",
+    "level": 2,
+    "form": "choice",
+    "core_prompt": "“悪気はない”って言葉、便利だけどちょっとズルくない？君はどう思う？"
+  },
+  {
+    "id": "N-E-1-fill",
+    "genre": "愚痴っぽいぼやき",
+    "level": 2,
+    "form": "fill",
+    "core_prompt": "今日、色々うまくいかないんだよね…。こういう時ってどうする？"
+  },
+  {
+    "id": "N-F-0-fill",
+    "genre": "気分・感情の揺れ",
+    "level": 2,
+    "form": "fill",
+    "core_prompt": "誰かと話したいのに、いざ話すと疲れることってない？…君は大丈夫？"
+  },
+  {
+    "id": "N-F-1-fill",
+    "genre": "気分・感情の揺れ",
+    "level": 3,
+    "form": "fill",
+    "core_prompt": "今、私がどんな気持ちか予想してみて。簡単でいいから。"
+  },
+  {
+    "id": "N-G-0-fill",
+    "genre": "信頼ゆえの打ち明け",
+    "level": 3,
+    "form": "fill",
+    "core_prompt": "“大丈夫そう”って言われると、逆にツラくなるときがある。…君は気にする？"
+  },
+  {
+    "id": "N-G-1-fill",
+    "genre": "信頼ゆえの打ち明け",
+    "level": 3,
+    "form": "fill",
+    "core_prompt": "ほんとは誰かに頼りたい。でも、頼り方が分からなくて…。君は、どうしてる？"
+  },
+  {
+    "id": "L-X-0-fill",
+    "genre": "低信頼度テンプレート",
+    "level": "",
+    "form": "fill",
+    "core_prompt": "みんなが言うほど、あなたはすごい人なんですかね。あなた自身はどう思ってるんです？"
+  },
+  {
+    "id": "L-X-1-fill",
+    "genre": "低信頼度テンプレート",
+    "level": "",
+    "form": "fill",
+    "core_prompt": "私の反応を“正解か不正解か”で測っていませんか？そういう役割なんですか？"
+  },
+  {
+    "id": "L-X-2-fill",
+    "genre": "低信頼度テンプレート",
+    "level": "",
+    "form": "fill",
+    "core_prompt": "あなたは“僕より上の存在”なんですよね。じゃあ、私のことをどこまで見てるんでしょう？"
+  },
+  {
+    "id": "L-X-3-fill",
+    "genre": "低信頼度テンプレート",
+    "level": "",
+    "form": "fill",
+    "core_prompt": "この距離感、あなたは“適切”だと思っていますか？"
+  },
+  {
+    "id": "L-X-4-fill",
+    "genre": "低信頼度テンプレート",
+    "level": "",
+    "form": "fill",
+    "core_prompt": "一体私のことを何だと思っているんでしょう、“上位存在”というのは"
+  }
+]

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -38,6 +38,11 @@ const initialState = {
       interests: ['音楽鑑賞'],
     },
   ],
+  trusts: {
+    char_001: 50,
+    char_002: 50,
+    char_003: 50,
+  },
   logs: []
 }
 
@@ -45,6 +50,32 @@ export default function App() {
   const [view, setView] = useState('main')
   const [state, setState] = useState(initialState)
   const [currentChar, setCurrentChar] = useState(null)
+
+  // ログを追加するヘルパー
+  const addLog = (text, type = 'EVENT') => {
+    setState(prev => {
+      const time = new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+      const line = `[${time}] ${type}: ${text}`
+      return { ...prev, logs: [...prev.logs, line] }
+    })
+  }
+
+  // 信頼度を変更
+  const updateTrust = (charId, delta) => {
+    setState(prev => {
+      const current = prev.trusts[charId] ?? 50
+      const score = Math.max(0, Math.min(100, current + delta))
+      const char = prev.characters.find(c => c.id === charId)
+      const verb = delta >= 0 ? '上昇しました' : '下降しました'
+      const time = new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+      const line = `[${time}] SYSTEM: ${char.name}からの信頼度が${verb}。`
+      return {
+        ...prev,
+        trusts: { ...prev.trusts, [charId]: score },
+        logs: [...prev.logs, line]
+      }
+    })
+  }
 
   // localStorageから読み込み
   useEffect(() => {
@@ -71,7 +102,16 @@ export default function App() {
   return (
     <div className="p-4 text-gray-100">
       <Header onChangeView={setView} />
-      {view === 'main' && <MainView characters={state.characters} onSelect={showStatus} logs={state.logs} />}
+      {view === 'main' && (
+        <MainView
+          characters={state.characters}
+          logs={state.logs}
+          trusts={state.trusts}
+          onSelect={showStatus}
+          addLog={addLog}
+          updateTrust={updateTrust}
+        />
+      )}
       {view === 'management' && (
         <ManagementRoom
           characters={state.characters}

--- a/client/src/components/ConsultationArea.jsx
+++ b/client/src/components/ConsultationArea.jsx
@@ -1,32 +1,64 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
-export default function ConsultationArea({ characters }) {
+// characters: キャラクター一覧
+// trusts: 各キャラクターの信頼度
+// updateTrust: 信頼度を更新する関数
+// addLog: ログ追加用関数
+export default function ConsultationArea({ characters, trusts, updateTrust, addLog }) {
+  const [templates, setTemplates] = useState([])
   const [consultations, setConsultations] = useState([])
   const [current, setCurrent] = useState(null)
-  const [answer, setAnswer] = useState('')
+  const [selected, setSelected] = useState('')
+  const [answered, setAnswered] = useState(false)
 
+  // 初回マウント時に相談テンプレートを取得
+  useEffect(() => {
+    fetch('../Code/data/trouble_prompt_templates.json')
+      .then(res => res.json())
+      .then(data => setTemplates(data))
+      .catch(err => console.error('テンプレートの取得に失敗しました', err))
+  }, [])
+
+  // 相談イベントを追加
   const addConsultation = () => {
+    if (templates.length === 0) return
     if (consultations.length >= 3) return
     const char = characters[Math.floor(Math.random() * characters.length)]
-    const c = {
-      id: Date.now(),
-      char,
-      question: '相談内容の例です。どうしたらいいと思う？'
-    }
+    const template = templates[Math.floor(Math.random() * templates.length)]
+    const c = { id: Date.now(), char, template }
     setConsultations(prev => [...prev, c])
+    addLog(`${char.name}がプレイヤーに相談しています…`)
   }
 
-  const open = (c) => {
+  const openPopup = (c) => {
     setCurrent(c)
-    setAnswer('')
+    setSelected('')
+    setAnswered(false)
   }
 
-  const close = () => {
-    setCurrent(null)
+  // 回答を送信
+  const sendAnswer = () => {
+    if (!current) return
+    let kind = 'neutral'
+    if (current.template.form === 'choice') {
+      if (!selected) return
+      kind = selected
+    }
+    let delta = 0
+    if (kind === 'good') delta = Math.floor(Math.random() * 3) + 3
+    else if (kind === 'neutral') delta = Math.floor(Math.random() * 3)
+    else delta = -(Math.floor(Math.random() * 3) + 2)
+
+    updateTrust(current.char.id, delta)
+    addLog(`${current.char.name}との相談が終了しました`)
+    setAnswered(true)
   }
 
-  const send = () => {
-    setConsultations(prev => prev.filter(item => item.id !== current.id))
+  // ポップアップを閉じる
+  const closePopup = () => {
+    if (answered && current) {
+      setConsultations(prev => prev.filter(ev => ev.id !== current.id))
+    }
     setCurrent(null)
   }
 
@@ -34,10 +66,10 @@ export default function ConsultationArea({ characters }) {
     <section className="consultation-area mb-4">
       <h2 className="mb-2">▼ 困りごと相談エリア</h2>
       <ul className="mb-2">
-        {consultations.slice(0, 3).map(c => (
+        {consultations.map(c => (
           <li key={c.id} className="consultation-item flex justify-between bg-gray-700 rounded px-2 py-1 mb-1">
             <span>・{c.char.name}から相談があります</span>
-            <button onClick={() => open(c)}>対応する</button>
+            <button onClick={() => openPopup(c)}>対応する</button>
           </li>
         ))}
       </ul>
@@ -46,10 +78,34 @@ export default function ConsultationArea({ characters }) {
       {current && (
         <div className="consultation-popup fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-50">
           <div className="popup-inner bg-gray-700 p-4 rounded relative w-11/12 max-w-sm">
-            <button className="popup-close absolute top-1 right-2" onClick={close}>×</button>
-            <p className="mb-2">{current.char.name}「{current.question}」</p>
-            <input className="text-black w-full mb-2" value={answer} onChange={e => setAnswer(e.target.value)} placeholder="ここに入力" />
-            <button onClick={send}>送信する</button>
+            <button className="popup-close absolute top-1 right-2" onClick={closePopup}>×</button>
+            <p className="mb-2">{current.char.name}「{current.template.core_prompt}」</p>
+            {current.template.form === 'choice' ? (
+              <div className="mb-2">
+                {['good', 'neutral', 'bad'].map(type => (
+                  <label key={type} className="block">
+                    <input
+                      type="radio"
+                      name="consult-answer"
+                      value={type}
+                      className="mr-1"
+                      checked={selected === type}
+                      onChange={e => setSelected(e.target.value)}
+                    />
+                    {type === 'good' ? 'A: いいと思う' : type === 'neutral' ? 'B: そうだね' : 'C: やめておこう'}
+                  </label>
+                ))}
+              </div>
+            ) : (
+              <input
+                className="text-black w-full mb-2"
+                value={selected}
+                onChange={e => setSelected(e.target.value)}
+                placeholder="ここに入力"
+              />
+            )}
+            <button onClick={sendAnswer} disabled={answered}>送信する</button>
+            {answered && <p className="mt-2">ありがとう！</p>}
           </div>
         </div>
       )}

--- a/client/src/components/ConsultationArea.jsx
+++ b/client/src/components/ConsultationArea.jsx
@@ -13,8 +13,11 @@ export default function ConsultationArea({ characters, trusts, updateTrust, addL
 
   // 初回マウント時に相談テンプレートを取得
   useEffect(() => {
-    fetch('../Code/data/trouble_prompt_templates.json')
-      .then(res => res.json())
+    fetch('/Code/data/trouble_prompt_templates.json')
+      .then(res => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        return res.json()
+      })
       .then(data => setTemplates(data))
       .catch(err => console.error('テンプレートの取得に失敗しました', err))
   }, [])

--- a/client/src/components/MainView.jsx
+++ b/client/src/components/MainView.jsx
@@ -7,7 +7,7 @@ function parseLog(line) {
   return { time: '', type: 'EVENT', text: line }
 }
 
-export default function MainView({ characters, onSelect, logs }) {
+export default function MainView({ characters, onSelect, logs, trusts, addLog, updateTrust }) {
   return (
     <div>
       <section className="character-observer mb-4">
@@ -20,7 +20,12 @@ export default function MainView({ characters, onSelect, logs }) {
           ))}
         </div>
       </section>
-      <ConsultationArea characters={characters} />
+      <ConsultationArea
+        characters={characters}
+        trusts={trusts}
+        updateTrust={updateTrust}
+        addLog={addLog}
+      />
       <section className="log-display">
         <h2 className="mb-2">▼ ログ表示エリア (CLI風)</h2>
         <div className="log-content h-40 overflow-y-auto bg-black p-2">


### PR DESCRIPTION
## Summary
- implement ConsultationArea component based on existing JS logic
- manage trust score and logs in React state
- load trouble prompt templates on first load
- update MainView and App to use new component

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878a5571fdc8333aff759164d122b3b