### PR TITLE
Add daily report filtering

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -46,7 +46,8 @@ const initialState = {
     char_002: 50,
     char_003: 50,
   },
-  logs: []
+  logs: [],
+  reports: {}
 }
 
 export default function App() {
@@ -84,7 +85,9 @@ export default function App() {
   useEffect(() => {
     const saved = localStorage.getItem(STORAGE_KEY)
     if (saved) {
-      setState(JSON.parse(saved))
+      const parsed = JSON.parse(saved)
+      parsed.reports = parsed.reports || {}
+      setState(parsed)
     }
   }, [])
 
@@ -162,7 +165,12 @@ export default function App() {
           onBack={() => setView('main')}
         />
       )}
-      {view === 'daily' && <DailyReport onBack={() => setView('main')} />}
+      {view === 'daily' && (
+        <DailyReport
+          reports={state.reports}
+          onBack={() => setView('main')}
+        />
+      )}
     </div>
   )
 }

--- a/client/src/components/DailyReport.jsx
+++ b/client/src/components/DailyReport.jsx
@@ -1,10 +1,64 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 
-export default function DailyReport({ onBack }) {
+// 日付文字列 (YYYY-MM-DD) を取得する簡易ヘルパー
+const todayStr = () => new Date().toISOString().split('T')[0]
+
+// reports: state.reports を想定
+export default function DailyReport({ reports = {}, onBack }) {
+  // 現在の日付を初期値とする
+  const [date, setDate] = useState(todayStr())
+  const [events, setEvents] = useState([])
+  const [changes, setChanges] = useState([])
+
+  // 日付変更や reports 更新時にリストを再取得
+  useEffect(() => {
+    const data = reports[date] || { events: [], changes: [] }
+    setEvents(data.events)
+    setChanges(data.changes)
+  }, [date, reports])
+
+  const formatTime = (ts) => new Date(ts).toTimeString().slice(0, 5)
+
   return (
     <section id="daily-report-view" className="view">
       <h2 className="mb-2">▼ 日報</h2>
-      <p className="mb-2">（日報データは未実装）</p>
+
+      {/* 日付選択エリア */}
+      <div className="report-filter mb-2">
+        <label htmlFor="report-date" className="mr-1">日付:</label>
+        <input
+          id="report-date"
+          type="date"
+          className="text-black"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+        />
+      </div>
+
+      {/* 発生イベント一覧 */}
+      <h3 className="mb-1">発生イベント</h3>
+      <ul className="mb-2">
+        {events.length === 0 ? (
+          <li>イベントがありません</li>
+        ) : (
+          events.map((ev, idx) => (
+            <li key={idx}>[{formatTime(ev.timestamp)}] {ev.description || ''}</li>
+          ))
+        )}
+      </ul>
+
+      {/* 変化履歴一覧 */}
+      <h3 className="mb-1">変化履歴</h3>
+      <ul className="mb-4">
+        {changes.length === 0 ? (
+          <li>変化はありません</li>
+        ) : (
+          changes.map((chg, idx) => (
+            <li key={idx}>[{chg.time}] {chg.description}</li>
+          ))
+        )}
+      </ul>
+
       <button onClick={onBack}>メインに戻る</button>
     </section>
   )


### PR DESCRIPTION
## Summary
- implement date filtering for daily reports with React hooks
- include reports in application state for display

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878aec819d48333a7e84c4cd05187be