### PR TITLE
Add save/load to React client

### DIFF
--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, useRef } from 'react'
 
-export default function Header({ onChangeView }) {
+export default function Header({ onChangeView, onSave, onLoad }) {
   const [time, setTime] = useState('')
   const [date, setDate] = useState('')
+  const fileInputRef = useRef(null)
 
   useEffect(() => {
     const update = () => {
@@ -19,6 +20,19 @@ export default function Header({ onChangeView }) {
     <header className="flex items-center gap-2 pb-4 mb-5 border-b border-gray-600">
       <button onClick={() => onChangeView('management')}>管理室</button>
       <button onClick={() => onChangeView('daily')}>日報</button>
+      <button onClick={onSave}>セーブ</button>
+      <button onClick={() => fileInputRef.current?.click()}>ロード</button>
+      <input
+        type="file"
+        accept="application/json"
+        className="hidden"
+        ref={fileInputRef}
+        onChange={(e) => {
+          const file = e.target.files?.[0]
+          if (file) onLoad(file)
+          e.target.value = ''
+        }}
+      />
       <div className="ml-auto text-right">
         <span id="time" className="font-bold mr-1">{time}</span>
         <span id="date">{date}</span>

--- a/client/src/lib/storage.js
+++ b/client/src/lib/storage.js
@@ -1,0 +1,57 @@
+// storage.js - 状態の保存と読み込み処理
+
+const STORAGE_KEY = 'relation_sim_state'
+
+export function saveStateToLocal(state) {
+  try {
+    const data = { ...state, logs: state.logs, reports: state.reports }
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data))
+  } catch (e) {
+    console.error('状態の保存に失敗しました', e)
+  }
+}
+
+export function loadStateFromLocal() {
+  const data = localStorage.getItem(STORAGE_KEY)
+  if (!data) return null
+  try {
+    const parsed = JSON.parse(data)
+    parsed.logs = parsed.logs || []
+    parsed.reports = parsed.reports || {}
+    return parsed
+  } catch (e) {
+    console.error('保存データの読み込みに失敗しました', e)
+    return null
+  }
+}
+
+export function exportState(state) {
+  const data = { ...state, logs: state.logs, reports: state.reports }
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = 'state.json'
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(url)
+}
+
+export function importStateFromFile(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => {
+      try {
+        const data = JSON.parse(reader.result)
+        data.logs = data.logs || []
+        data.reports = data.reports || {}
+        resolve(data)
+      } catch (e) {
+        reject(e)
+      }
+    }
+    reader.onerror = () => reject(reader.error)
+    reader.readAsText(file)
+  })
+}


### PR DESCRIPTION
## Summary
- implement state export/import helpers for React
- add Save/Load buttons in the header
- wire up save/load logic in App component

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878d89ab3f483339fe1d18b99de6749