### PR TITLE
補足表示の追加

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -25,6 +25,7 @@ const initialState = {
       talkStyle: { preset: 'くだけた', firstPerson: '俺', suffix: '〜じゃん' },
       activityPattern: '夜型',
       interests: ['読書', '散歩'],
+      condition: '活動中',
     },
     {
       id: 'char_002',
@@ -34,6 +35,7 @@ const initialState = {
       talkStyle: { preset: '丁寧', firstPerson: '私', suffix: '〜です' },
       activityPattern: '朝型',
       interests: ['お菓子作り', 'カフェ巡り'],
+      condition: '活動中',
     },
     {
       id: 'char_003',
@@ -43,6 +45,7 @@ const initialState = {
       talkStyle: { preset: 'くだけた', firstPerson: 'ボク', suffix: '〜だよ' },
       activityPattern: '通常',
       interests: ['音楽鑑賞'],
+      condition: '活動中',
     },
   ],
   relationships: [], // キャラクター同士の関係
@@ -196,6 +199,7 @@ export default function App() {
           char={currentChar}
           characters={state.characters}
           logs={state.logs}
+          trusts={state.trusts}
           onBack={() => setView('main')}
         />
       )}

--- a/client/src/components/CharacterStatus.jsx
+++ b/client/src/components/CharacterStatus.jsx
@@ -9,8 +9,11 @@ function parseLog(line) {
 
 // characters: 全キャラクター一覧
 // logs: これまでのログ
-export default function CharacterStatus({ char, characters = [], logs = [], onBack }) {
+export default function CharacterStatus({ char, characters = [], logs = [], trusts = [], onBack }) {
   const p = char.personality || {}
+  const talk = char.talkStyle || {}
+  const trustRec = trusts.find(t => t.id === char.id)
+  const trust = trustRec ? trustRec.score : 50
 
   // 簡易的な関係情報を生成（現状ダミー）
   const relations = characters
@@ -35,6 +38,13 @@ export default function CharacterStatus({ char, characters = [], logs = [], onBa
       <div className="basic-info mb-2">
         <p>名前: {char.name}</p>
         <p>MBTI: {char.mbti}</p>
+        <p>話し方プリセット: {talk.preset || '未設定'}</p>
+        <p>一人称: {talk.firstPerson || '未設定'}</p>
+        <p>語尾: {talk.suffix || '未設定'}</p>
+        <p>現在状態: {char.condition || '活動中'}</p>
+        <p>活動傾向: {char.activityPattern || '通常'}</p>
+        <p>信頼度: {trust}</p>
+        <p>興味関心: {(char.interests || []).length > 0 ? char.interests.join(', ') : 'なし'}</p>
       </div>
 
       {/* 性格パラメータのバー表示 */}

--- a/client/src/components/ManagementRoom.jsx
+++ b/client/src/components/ManagementRoom.jsx
@@ -110,6 +110,7 @@ export default function ManagementRoom({
     e.preventDefault()
     if (!name) return
     const id = editingId || 'char_' + Date.now()
+    const existing = characters.find(c => c.id === id)
     const char = {
       id,
       name,
@@ -118,7 +119,8 @@ export default function ManagementRoom({
       mbti_slider: mbtiMode === 'diag' ? mbtiSliders : [],
       talkStyle: { preset: talkPreset, firstPerson, suffix },
       activityPattern,
-      interests: interests.split(',').map(i => i.trim()).filter(i => i)
+      interests: interests.split(',').map(i => i.trim()).filter(i => i),
+      condition: existing?.condition || '活動中'
     }
     const rels = []
     const nicks = []


### PR DESCRIPTION
## Summary
- キャラクターステータス画面に話し方や興味関心などの情報を追加
- 管理室から保存するキャラクターに状態を保持
- ステータス画面表示時に信頼度を参照

## Testing
- `npm install` *(失敗)*
- `npm run build` *(失敗: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878df5465388333b6d55a927fc146f4