### PR TITLE
Implement real relationship display

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -200,6 +200,10 @@ export default function App() {
           characters={state.characters}
           logs={state.logs}
           trusts={state.trusts}
+          relationships={state.relationships}
+          nicknames={state.nicknames}
+          affections={state.affections}
+          emotions={state.emotions}
           onBack={() => setView('main')}
         />
       )}


### PR DESCRIPTION
## Summary
- show actual relationships on character status view using relationship, affection and emotion data
- pass needed props from App to CharacterStatus

## Testing
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878e305410c83339acdf850c1632017