### PR TITLE
Add daily report utils to React version

### DIFF
--- a/client/src/lib/emotionLabel.js
+++ b/client/src/lib/emotionLabel.js
@@ -1,5 +1,7 @@
 // emotionLabel.js - 感情ラベル関連処理
 
+import { addReportChange } from './reportUtils.js'
+
 let drawTable = null
 export const specialRelations = ['恋人', '親友', '家族']
 
@@ -85,15 +87,15 @@ function ensureEmotionRecord(state, emotions, from, to) {
 }
 
 // 感情ラベル変化抽選
-export function drawEmotionChange(state, emotions, from, to, mood) {
-  if (!drawTable) return { emotions, log: null }
+export function drawEmotionChange(state, emotions, from, to, mood, reports = {}) {
+  if (!drawTable) return { emotions, log: null, reports }
   let next = ensureEmotionRecord(state, emotions, from, to)
   const relation = getRelationLabel(state, from, to)
   const current = getEmotionLabel({ ...state, emotions: next }, from, to)
   const tableRoot = specialRelations.includes(relation) ? drawTable.special_relationship : drawTable.normal_relationship
   const key = (specialRelations.includes(relation) ? '特殊_' : '通常_') + current
   const moodWeights = tableRoot[key]?.[moodText[String(mood)]]
-  if (!moodWeights) return { emotions: next, log: null }
+  if (!moodWeights) return { emotions: next, log: null, reports }
   let total = 0
   Object.values(moodWeights).forEach(v => { total += v })
   let rnd = Math.random() * total
@@ -107,7 +109,8 @@ export function drawEmotionChange(state, emotions, from, to, mood) {
     const fromName = state.characters.find(c => c.id === from)?.name || from
     const toName = state.characters.find(c => c.id === to)?.name || to
     const log = `${fromName}→${toName}の印象が「${result}」に変化しました。`
-    return { emotions: next, log }
+    reports = addReportChange(reports, `${fromName}→${toName}の印象「${current}」→「${result}」`)
+    return { emotions: next, log, reports }
   }
-  return { emotions: next, log: null }
+  return { emotions: next, log: null, reports }
 }

--- a/client/src/lib/reportUtils.js
+++ b/client/src/lib/reportUtils.js
@@ -1,0 +1,40 @@
+// reportUtils.js - 日報管理のユーティリティ
+// state.reports を更新する純粋関数として実装します
+
+/**
+ * イベント発生を reports に記録します。
+ * @param {Object} reports - 現在の reports オブジェクト
+ * @param {Object} event - { timestamp, description } などの情報
+ * @returns {Object} 更新後の reports
+ */
+export function addReportEvent(reports, event) {
+  const dateKey = new Date(event.timestamp).toISOString().split('T')[0]
+  const data = reports[dateKey] || { events: [], changes: [] }
+  return {
+    ...reports,
+    [dateKey]: {
+      events: [...data.events, event],
+      changes: data.changes,
+    },
+  }
+}
+
+/**
+ * 状態変化を reports に記録します。
+ * @param {Object} reports - 現在の reports オブジェクト
+ * @param {string} description - 変化内容の説明
+ * @returns {Object} 更新後の reports
+ */
+export function addReportChange(reports, description) {
+  const now = new Date()
+  const dateKey = now.toISOString().split('T')[0]
+  const time = now.toTimeString().slice(0, 5)
+  const data = reports[dateKey] || { events: [], changes: [] }
+  return {
+    ...reports,
+    [dateKey]: {
+      events: data.events,
+      changes: [...data.changes, { time, description }],
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- add `reportUtils.js` with helpers to update reports
- record affection and emotion changes in `eventSystem` and `emotionLabel`
- log random events and changes into daily reports

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879cab4c514833388bfd4d1f020d3a9