### PR TITLE
Add last consultation tracking

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -26,6 +26,7 @@ const initialState = {
       activityPattern: '夜型',
       interests: ['読書', '散歩'],
       condition: '活動中',
+      lastConsultation: 0,
     },
     {
       id: 'char_002',
@@ -36,6 +37,7 @@ const initialState = {
       activityPattern: '朝型',
       interests: ['お菓子作り', 'カフェ巡り'],
       condition: '活動中',
+      lastConsultation: 0,
     },
     {
       id: 'char_003',
@@ -46,6 +48,7 @@ const initialState = {
       activityPattern: '通常',
       interests: ['音楽鑑賞'],
       condition: '活動中',
+      lastConsultation: 0,
     },
   ],
   relationships: [], // キャラクター同士の関係
@@ -98,6 +101,17 @@ export default function App() {
         logs: [...prev.logs, line]
       }
     })
+  }
+
+  // キャラクターが相談を行った時間を更新
+  const updateLastConsultation = (charId) => {
+    const now = Date.now()
+    setState(prev => ({
+      ...prev,
+      characters: prev.characters.map(c =>
+        c.id === charId ? { ...c, lastConsultation: now } : c
+      )
+    }))
   }
 
   // localStorageから読み込み
@@ -181,6 +195,7 @@ export default function App() {
           onSelect={showStatus}
           addLog={addLog}
           updateTrust={updateTrust}
+          updateLastConsultation={updateLastConsultation}
         />
       )}
       {view === 'management' && (

--- a/client/src/components/ConsultationArea.jsx
+++ b/client/src/components/ConsultationArea.jsx
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from 'react'
 // trusts: 各キャラクターの信頼度
 // updateTrust: 信頼度を更新する関数
 // addLog: ログ追加用関数
-export default function ConsultationArea({ characters, trusts, updateTrust, addLog }) {
+export default function ConsultationArea({ characters, trusts, updateTrust, addLog, updateLastConsultation }) {
   const [templates, setTemplates] = useState([])
   const [consultations, setConsultations] = useState([])
   const [current, setCurrent] = useState(null)
@@ -28,13 +28,16 @@ export default function ConsultationArea({ characters, trusts, updateTrust, addL
     const timer = setInterval(() => {
       setConsultations(prev => {
         if (prev.length > 0 || templates.length === 0) return prev
-        const char = characters[Math.floor(Math.random() * characters.length)]
+        const available = characters.filter(c => Date.now() - (c.lastConsultation || 0) >= AUTO_INTERVAL_MS)
+        if (available.length === 0) return prev
+        const char = available[Math.floor(Math.random() * available.length)]
         const template = templates[Math.floor(Math.random() * templates.length)]
         const id = Date.now()
         const timeout = setTimeout(() => {
           setConsultations(p => p.filter(c => c.id !== id))
         }, AUTO_INTERVAL_MS)
         addLog(`${char.name}がプレイヤーに相談しています…`)
+        updateLastConsultation(char.id)
         return [...prev, { id, char, template, timeout }]
       })
     }, AUTO_INTERVAL_MS)
@@ -45,7 +48,9 @@ export default function ConsultationArea({ characters, trusts, updateTrust, addL
   const addConsultation = () => {
     if (templates.length === 0) return
     if (consultations.length >= 3) return
-    const char = characters[Math.floor(Math.random() * characters.length)]
+    const available = characters.filter(c => Date.now() - (c.lastConsultation || 0) >= AUTO_INTERVAL_MS)
+    if (available.length === 0) return
+    const char = available[Math.floor(Math.random() * available.length)]
     const template = templates[Math.floor(Math.random() * templates.length)]
     const id = Date.now()
     const timeout = setTimeout(() => {
@@ -54,6 +59,7 @@ export default function ConsultationArea({ characters, trusts, updateTrust, addL
     const c = { id, char, template, timeout }
     setConsultations(prev => [...prev, c])
     addLog(`${char.name}がプレイヤーに相談しています…`)
+    updateLastConsultation(char.id)
   }
 
   const openPopup = (c) => {
@@ -76,6 +82,7 @@ export default function ConsultationArea({ characters, trusts, updateTrust, addL
     else delta = -(Math.floor(Math.random() * 3) + 2)
 
     updateTrust(current.char.id, delta)
+    updateLastConsultation(current.char.id)
     addLog(`${current.char.name}との相談が終了しました`)
     clearTimeout(current.timeout)
     setAnswered(true)

--- a/client/src/components/MainView.jsx
+++ b/client/src/components/MainView.jsx
@@ -7,7 +7,7 @@ function parseLog(line) {
   return { time: '', type: 'EVENT', text: line }
 }
 
-export default function MainView({ characters, onSelect, logs, trusts, addLog, updateTrust }) {
+export default function MainView({ characters, onSelect, logs, trusts, addLog, updateTrust, updateLastConsultation }) {
   const logRef = useRef(null)
 
   useEffect(() => {
@@ -33,6 +33,7 @@ export default function MainView({ characters, onSelect, logs, trusts, addLog, u
         trusts={trusts}
         updateTrust={updateTrust}
         addLog={addLog}
+        updateLastConsultation={updateLastConsultation}
       />
       <section className="mb-6">
         <h2 className="text-sm text-gray-300 border-b border-gray-600 pb-1 mb-2">▼ ログ表示エリア (CLI風)</h2>

--- a/client/src/components/ManagementRoom.jsx
+++ b/client/src/components/ManagementRoom.jsx
@@ -120,7 +120,8 @@ export default function ManagementRoom({
       talkStyle: { preset: talkPreset, firstPerson, suffix },
       activityPattern,
       interests: interests.split(',').map(i => i.trim()).filter(i => i),
-      condition: existing?.condition || '活動中'
+      condition: existing?.condition || '活動中',
+      lastConsultation: existing?.lastConsultation || 0
     }
     const rels = []
     const nicks = []


### PR DESCRIPTION
## Summary
- track `lastConsultation` in initial characters
- keep new character's `lastConsultation` at creation
- prevent over-frequent consultations
- update consultation timestamp when events start and end

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6879ced730788333b905322494157335