### PR TITLE
Add condition display on character cards

### DIFF
--- a/client/src/components/MainView.jsx
+++ b/client/src/components/MainView.jsx
@@ -22,8 +22,15 @@ export default function MainView({ characters, onSelect, logs, trusts, addLog, u
         <h2 className="text-sm text-gray-300 border-b border-gray-600 pb-1 mb-2">▼ みんなの様子</h2>
         <div className="flex overflow-x-auto gap-2 pb-2">
           {characters.map(c => (
-            <div key={c.id} className="flex-shrink-0 w-24 h-16 bg-gray-600 border border-gray-500 rounded flex items-center justify-center cursor-pointer" onClick={() => onSelect(c)}>
-              {c.name}
+            <div
+              key={c.id}
+              className="flex-shrink-0 w-24 h-16 bg-gray-600 border border-gray-500 rounded flex flex-col items-center justify-center cursor-pointer"
+              onClick={() => onSelect(c)}
+            >
+              <span>{c.name}</span>
+              {c.condition && (
+                <span className="text-xs text-gray-300">{c.condition}</span>
+              )}
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- MainView でキャラクターカードに `c.condition` を追加
- 文字列が存在する場合のみ表示
- Tailwind を使って既存カードに合わせたデザインに調整

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879f87055cc8333821cb9e29b41f60b