### PR TITLE
Add relation detail view and navigation

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -10,6 +10,7 @@ import Header from './components/Header.jsx'
 import MainView from './components/MainView.jsx'
 import ManagementRoom from './components/ManagementRoom.jsx'
 import CharacterStatus from './components/CharacterStatus.jsx'
+import RelationDetail from './components/RelationDetail.jsx'
 import DailyReport from './components/DailyReport.jsx'
 import { addReportChange } from './lib/reportUtils.js'
 const EVENT_INTERVAL_MS = 1800000 // 30分ごと
@@ -70,6 +71,7 @@ export default function App() {
   const [view, setView] = useState('main')
   const [state, setState] = useState(initialState)
   const [currentChar, setCurrentChar] = useState(null)
+  const [currentPair, setCurrentPair] = useState(null)
 
   // ログを追加するヘルパー
   const addLog = (text, type = 'EVENT') => {
@@ -269,7 +271,16 @@ export default function App() {
 
   const showStatus = (char) => {
     setCurrentChar(char)
+    setCurrentPair(null)
     setView('status')
+  }
+
+  const showRelationDetail = (idA, idB) => {
+    const a = state.characters.find(c => c.id === idA)
+    const b = state.characters.find(c => c.id === idB)
+    if (!a || !b) return
+    setCurrentPair({ a, b })
+    setView('relation')
   }
 
   return (
@@ -294,7 +305,10 @@ export default function App() {
           affections={state.affections}
           onSaveCharacter={saveCharacter}
           onDeleteCharacter={deleteCharacter}
-          onBack={() => setView('main')}
+          onBack={() => {
+            setCurrentPair(null)
+            setView('main')
+          }}
         />
       )}
       {view === 'status' && currentChar && (
@@ -307,7 +321,25 @@ export default function App() {
           nicknames={state.nicknames}
           affections={state.affections}
           emotions={state.emotions}
-          onBack={() => setView('main')}
+          onBack={() => {
+            setCurrentPair(null)
+            setView('main')
+          }}
+          onOpenRelation={showRelationDetail}
+        />
+      )}
+      {view === 'relation' && currentPair && (
+        <RelationDetail
+          charA={currentPair.a}
+          charB={currentPair.b}
+          relationships={state.relationships}
+          affections={state.affections}
+          emotions={state.emotions}
+          logs={state.logs}
+          onBack={() => {
+            setCurrentPair(null)
+            setView('status')
+          }}
         />
       )}
       {view === 'daily' && (

--- a/client/src/components/CharacterStatus.jsx
+++ b/client/src/components/CharacterStatus.jsx
@@ -28,6 +28,7 @@ export default function CharacterStatus({
   affections = [],
   emotions = [],
   onBack,
+  onOpenRelation,
 }) {
   const p = char.personality || {}
   const talk = char.talkStyle || {}
@@ -55,6 +56,7 @@ export default function CharacterStatus({
       const emotion = getEmotionLabel({ emotions }, char.id, other.id) || 'なし'
 
       return {
+        otherId: other.id,
         otherName: other.name,
         label,
         affectionTo,
@@ -120,7 +122,12 @@ export default function CharacterStatus({
           <p>関係情報なし</p>
         ) : (
           relations.map((rel, idx) => (
-            <RelationItem key={idx} charName={char.name} relation={rel} />
+            <RelationItem
+              key={idx}
+              charName={char.name}
+              relation={rel}
+              onOpen={() => onOpenRelation && onOpenRelation(char.id, rel.otherId)}
+            />
           ))
         )}
       </div>

--- a/client/src/components/RelationDetail.jsx
+++ b/client/src/components/RelationDetail.jsx
@@ -1,0 +1,94 @@
+import React from 'react'
+import { getEmotionLabel } from '../lib/emotionLabel.js'
+
+// ログ行をパースして {time, text} を返す簡易関数
+function parseLog(line) {
+  const m = line.match(/^\[(.*?)\]\s*(EVENT|SYSTEM):\s*(.*)$/)
+  if (m) return { time: m[1], text: m[3] }
+  return { time: '', text: line }
+}
+
+// 好感度スコア(-100~100)を0~100のパーセントに変換
+function affectionToPercent(score) {
+  const clamped = Math.max(-100, Math.min(100, score))
+  return (clamped + 100) / 2
+}
+
+// charA, charB: 対象キャラオブジェクト
+// relationships, affections, emotions: 全体の状態
+export default function RelationDetail({
+  charA,
+  charB,
+  relationships = [],
+  affections = [],
+  emotions = [],
+  logs = [],
+  onBack,
+}) {
+  const pair = [charA.id, charB.id].sort()
+  const relRec = relationships.find(r => r.pair[0] === pair[0] && r.pair[1] === pair[1])
+  const label = relRec ? relRec.label : 'なし'
+
+  const affectionAB = affections.find(a => a.from === charA.id && a.to === charB.id)?.score || 0
+  const affectionBA = affections.find(a => a.from === charB.id && a.to === charA.id)?.score || 0
+
+  const emotionAB = getEmotionLabel({ emotions }, charA.id, charB.id) || 'なし'
+  const emotionBA = getEmotionLabel({ emotions }, charB.id, charA.id) || 'なし'
+
+  // 両名が登場するログを抽出し新しいものから5件表示
+  const histories = logs
+    .filter(l => l.includes(charA.name) && l.includes(charB.name))
+    .slice(-5)
+    .map(parseLog)
+    .reverse()
+
+  return (
+    <section className="mb-6">
+      <h2 className="text-sm text-gray-300 border-b border-gray-600 pb-1 mb-2">
+        ▼ {charA.name}⇄{charB.name} 関係詳細
+      </h2>
+      <div className="flex justify-between mb-2">
+        <div>
+          <p>キャラA: {charA.name}</p>
+        </div>
+        <div>
+          <p>キャラB: {charB.name}</p>
+        </div>
+      </div>
+      <p className="mb-2">関係ラベル: {label}</p>
+      <div className="grid grid-cols-2 gap-4 mb-4">
+        <div>
+          <p className="mb-1">[{charA.name} → {charB.name}]</p>
+          <p className="flex items-center mb-1">
+            <span className="mr-1">好感度:</span>
+            <progress value={affectionToPercent(affectionAB)} max="100" className="w-full h-2" />
+          </p>
+          <p>感情ラベル: {emotionAB}</p>
+        </div>
+        <div>
+          <p className="mb-1">[{charB.name} → {charA.name}]</p>
+          <p className="flex items-center mb-1">
+            <span className="mr-1">好感度:</span>
+            <progress value={affectionToPercent(affectionBA)} max="100" className="w-full h-2" />
+          </p>
+          <p>感情ラベル: {emotionBA}</p>
+        </div>
+      </div>
+      <h3 className="text-sm text-gray-300 border-b border-gray-600 pb-1 mb-2">▼ 最近のやり取り履歴</h3>
+      <ul className="list-disc pl-4 mb-2">
+        {histories.length === 0 ? (
+          <li>履歴なし</li>
+        ) : (
+          histories.map((h, idx) => (
+            <li key={idx}>
+              {h.time && <span className="mr-1">[{h.time}]</span>}
+              {h.text}
+            </li>
+          ))
+        )}
+      </ul>
+      <button className="mt-4" onClick={onBack}>戻る</button>
+    </section>
+  )
+}
+

--- a/client/src/components/RelationItem.jsx
+++ b/client/src/components/RelationItem.jsx
@@ -8,7 +8,7 @@ function affectionToPercent(score) {
   return (clamped + 100) / 2
 }
 
-export default function RelationItem({ charName, relation }) {
+export default function RelationItem({ charName, relation, onOpen }) {
   return (
     <details className="flex-shrink-0 w-60 bg-gray-700 border border-gray-600 rounded p-2">
       <summary className="cursor-pointer list-none">
@@ -16,6 +16,18 @@ export default function RelationItem({ charName, relation }) {
         <p className="text-sm">
           {relation.label} | 印象: {relation.emotion}
         </p>
+        {onOpen && (
+          <button
+            type="button"
+            className="ml-2 text-blue-300 underline"
+            onClick={e => {
+              e.stopPropagation()
+              onOpen()
+            }}
+          >
+            詳細
+          </button>
+        )}
       </summary>
       <div className="mt-2 ml-2 text-sm">
         <p>[{charName} → {relation.otherName}]</p>


### PR DESCRIPTION
## Summary
- create `RelationDetail` component to show relations and logs
- add navigation from relation cards to detail view
- extend `CharacterStatus` and `App` to handle new view

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879fcf286fc83338690e9cea10c9981