### PR TITLE
Add log detail viewer and link reports

### DIFF
--- a/client/src/components/CharacterStatus.jsx
+++ b/client/src/components/CharacterStatus.jsx
@@ -4,9 +4,12 @@ import RelationItem from './RelationItem.jsx'
 
 // ログ文字列をパースする簡易関数
 function parseLog(line) {
-  const m = line.match(/^\[(.*?)\]\s*(EVENT|SYSTEM):\s*(.*)$/)
-  if (m) return { time: m[1], text: m[3] }
-  return { time: '', text: line }
+  if (typeof line === 'string') {
+    const m = line.match(/^\[(.*?)\]\s*(EVENT|SYSTEM):\s*(.*)$/)
+    if (m) return { time: m[1], text: m[3] }
+    return { time: '', text: line }
+  }
+  return line
 }
 
 // 好感度スコア(-100〜100)を0〜100のパーセントに変換

--- a/client/src/components/DailyReport.jsx
+++ b/client/src/components/DailyReport.jsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect } from 'react'
 const todayStr = () => new Date().toISOString().split('T')[0]
 
 // reports: state.reports を想定
-export default function DailyReport({ reports = {}, characters = [], onBack }) {
+export default function DailyReport({ reports = {}, characters = [], onBack, onOpenLog }) {
   // 現在の日付を初期値とする
   const [date, setDate] = useState(todayStr())
   const [events, setEvents] = useState([])
@@ -111,7 +111,13 @@ export default function DailyReport({ reports = {}, characters = [], onBack }) {
           <li>イベントがありません</li>
         ) : (
           events.map((ev, idx) => (
-            <li key={idx}>[{formatTime(ev.timestamp)}] {ev.description || ''}</li>
+            <li
+              key={idx}
+              className={ev.logId ? 'cursor-pointer text-blue-300' : ''}
+              onClick={() => ev.logId && onOpenLog && onOpenLog(ev.logId)}
+            >
+              [{formatTime(ev.timestamp)}] {ev.description || ''}
+            </li>
           ))
         )}
       </ul>
@@ -123,7 +129,13 @@ export default function DailyReport({ reports = {}, characters = [], onBack }) {
           <li>変化はありません</li>
         ) : (
           changes.map((chg, idx) => (
-            <li key={idx}>[{chg.time}] {chg.description}</li>
+            <li
+              key={idx}
+              className={chg.logId ? 'cursor-pointer text-blue-300' : ''}
+              onClick={() => chg.logId && onOpenLog && onOpenLog(chg.logId)}
+            >
+              [{chg.time}] {chg.description}
+            </li>
           ))
         )}
       </ul>

--- a/client/src/components/LogDetail.jsx
+++ b/client/src/components/LogDetail.jsx
@@ -1,0 +1,27 @@
+import React from 'react'
+
+export default function LogDetail({ log = null, onBack }) {
+  if (!log) {
+    return (
+      <section className="mb-6">
+        <h2 className="text-sm text-gray-300 border-b border-gray-600 pb-1 mb-2">ログ詳細</h2>
+        <p>ログが見つかりません。</p>
+        <button className="mt-4" onClick={onBack}>戻る</button>
+      </section>
+    )
+  }
+
+  return (
+    <section className="mb-6">
+      <h2 className="text-sm text-gray-300 border-b border-gray-600 pb-1 mb-2">ログ詳細</h2>
+      <p className="mb-2">
+        {log.time && <span className="mr-1">[{log.time}]</span>}
+        {log.type}: {log.text}
+      </p>
+      <pre className="whitespace-pre-wrap mb-4 bg-gray-700 p-2 rounded">
+        {log.detail || '詳細はありません'}
+      </pre>
+      <button onClick={onBack}>戻る</button>
+    </section>
+  )
+}

--- a/client/src/components/MainView.jsx
+++ b/client/src/components/MainView.jsx
@@ -2,9 +2,12 @@ import React, { useEffect, useRef } from 'react'
 import ConsultationArea from './ConsultationArea.jsx'
 
 function parseLog(line) {
-  const m = line.match(/^\[(.*?)\]\s*(EVENT|SYSTEM):\s*(.*)$/)
-  if (m) return { time: m[1], type: m[2], text: m[3] }
-  return { time: '', type: 'EVENT', text: line }
+  if (typeof line === 'string') {
+    const m = line.match(/^\[(.*?)\]\s*(EVENT|SYSTEM):\s*(.*)$/)
+    if (m) return { time: m[1], type: m[2], text: m[3] }
+    return { time: '', type: 'EVENT', text: line }
+  }
+  return line
 }
 
 export default function MainView({ characters, onSelect, logs, trusts, addLog, updateTrust, updateLastConsultation }) {

--- a/client/src/components/RelationDetail.jsx
+++ b/client/src/components/RelationDetail.jsx
@@ -3,9 +3,12 @@ import { getEmotionLabel } from '../lib/emotionLabel.js'
 
 // ログ行をパースして {time, text} を返す簡易関数
 function parseLog(line) {
-  const m = line.match(/^\[(.*?)\]\s*(EVENT|SYSTEM):\s*(.*)$/)
-  if (m) return { time: m[1], text: m[3] }
-  return { time: '', text: line }
+  if (typeof line === 'string') {
+    const m = line.match(/^\[(.*?)\]\s*(EVENT|SYSTEM):\s*(.*)$/)
+    if (m) return { time: m[1], text: m[3] }
+    return { time: '', text: line }
+  }
+  return line
 }
 
 // 好感度スコア(-100~100)を0~100のパーセントに変換
@@ -37,7 +40,10 @@ export default function RelationDetail({
 
   // 両名が登場するログを抽出し新しいものから5件表示
   const histories = logs
-    .filter(l => l.includes(charA.name) && l.includes(charB.name))
+    .filter(l => {
+      const text = typeof l === 'string' ? l : l.text || ''
+      return text.includes(charA.name) && text.includes(charB.name)
+    })
     .slice(-5)
     .map(parseLog)
     .reverse()

--- a/client/src/lib/reportUtils.js
+++ b/client/src/lib/reportUtils.js
@@ -25,7 +25,7 @@ export function addReportEvent(reports, event) {
  * @param {string} description - 変化内容の説明
  * @returns {Object} 更新後の reports
  */
-export function addReportChange(reports, description) {
+export function addReportChange(reports, description, logId = null) {
   const now = new Date()
   const dateKey = now.toISOString().split('T')[0]
   const time = now.toTimeString().slice(0, 5)
@@ -34,7 +34,7 @@ export function addReportChange(reports, description) {
     ...reports,
     [dateKey]: {
       events: data.events,
-      changes: [...data.changes, { time, description }],
+      changes: [...data.changes, { time, description, logId }],
     },
   }
 }

--- a/client/src/lib/storage.js
+++ b/client/src/lib/storage.js
@@ -16,7 +16,16 @@ export function loadStateFromLocal() {
   if (!data) return null
   try {
     const parsed = JSON.parse(data)
-    parsed.logs = parsed.logs || []
+    parsed.logs = (parsed.logs || []).map(l => {
+      if (typeof l === 'string') {
+        const m = l.match(/^\[(.*?)\]\s*(EVENT|SYSTEM):\s*(.*)$/)
+        if (m) {
+          return { id: Date.now().toString(36), time: m[1], type: m[2], text: m[3], detail: m[3] }
+        }
+        return { id: Date.now().toString(36), time: '', type: 'EVENT', text: l, detail: l }
+      }
+      return l
+    })
     parsed.reports = parsed.reports || {}
     return parsed
   } catch (e) {
@@ -44,7 +53,17 @@ export function importStateFromFile(file) {
     reader.onload = () => {
       try {
         const data = JSON.parse(reader.result)
-        data.logs = data.logs || []
+        data.logs = (data.logs || []).map(l => {
+          if (typeof l === 'string') {
+            const m = l.match(/^\[(.*?)\]\s*(EVENT|SYSTEM):\s*(.*)$/)
+            if (m) {
+              return { id: Date.now().toString(36), time: m[1], type: m[2], text: m[3], detail: m[3] }
+            }
+            return { id: Date.now().toString(36), time: '', type: 'EVENT', text: l, detail: l }
+          }
+          return l
+        })
+        data.reports = data.reports || {}
         data.reports = data.reports || {}
         resolve(data)
       } catch (e) {


### PR DESCRIPTION
## Summary
- support storing full log entries with an id
- display log details via new `LogDetail` component
- enable clicking items in `DailyReport` to open corresponding log
- update random event system to record log IDs
- convert old log strings when loading from storage

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879ff18f8a48333a6200e9d40cbddd0