### PR TITLE
ログ表示をコンポーネント化

### DIFF
--- a/client/src/components/LogList.jsx
+++ b/client/src/components/LogList.jsx
@@ -1,0 +1,120 @@
+import React, { useEffect, useRef, useState } from 'react'
+
+function parseLog(line) {
+  if (typeof line === 'string') {
+    const m = line.match(/^\[(.*?)\]\s*(EVENT|SYSTEM):\s*(.*)$/)
+    if (m) return { id: m[1] + m[2], time: m[1], type: m[2], text: m[3] }
+    return { id: Date.now().toString(36), time: '', type: 'EVENT', text: line }
+  }
+  return line
+}
+
+function LogLine({ line }) {
+  const { time, type, text } = parseLog(line)
+  const [shown, setShown] = useState('')
+
+  useEffect(() => {
+    let i = 0
+    const timer = setInterval(() => {
+      i++
+      setShown(text.slice(0, i))
+      if (i >= text.length) clearInterval(timer)
+    }, 20)
+    return () => clearInterval(timer)
+  }, [text])
+
+  const cls = type === 'SYSTEM' ? 'text-orange-300 font-bold' : 'text-blue-400 font-bold'
+
+  return (
+    <p className="mb-1">
+      {time && <span className="text-gray-400 mr-1">[{time}]</span>}
+      <span className={cls}>{type}:</span> {shown}
+    </p>
+  )
+}
+
+export default function LogList({ logs = [] }) {
+  const logRef = useRef(null)
+  const [order, setOrder] = useState('old')
+  const [showBanner, setShowBanner] = useState(false)
+  const prevLen = useRef(logs.length)
+
+  const checkScroll = () => {
+    const div = logRef.current
+    if (!div) return
+    if (order === 'old') {
+      const bottom = div.scrollTop + div.clientHeight >= div.scrollHeight - 5
+      setShowBanner(!bottom)
+    } else {
+      const top = div.scrollTop <= 5
+      setShowBanner(!top)
+    }
+  }
+
+  useEffect(() => {
+    const div = logRef.current
+    if (!div) return
+    div.addEventListener('scroll', checkScroll)
+    return () => div.removeEventListener('scroll', checkScroll)
+  }, [order])
+
+  useEffect(() => {
+    const div = logRef.current
+    if (!div) return
+    if (order === 'old') {
+      const bottom = div.scrollTop + div.clientHeight >= div.scrollHeight - 5
+      if (bottom) {
+        div.scrollTop = div.scrollHeight
+      } else if (prevLen.current !== logs.length) {
+        setShowBanner(true)
+      }
+    } else {
+      const top = div.scrollTop <= 5
+      if (top) {
+        div.scrollTop = 0
+      } else if (prevLen.current !== logs.length) {
+        setShowBanner(true)
+      }
+    }
+    prevLen.current = logs.length
+  }, [logs, order])
+
+  const ordered = order === 'old' ? logs : [...logs].slice().reverse()
+
+  const handleBannerClick = () => {
+    const div = logRef.current
+    if (!div) return
+    if (order === 'old') {
+      div.scrollTop = div.scrollHeight
+    } else {
+      div.scrollTop = 0
+    }
+    setShowBanner(false)
+  }
+
+  return (
+    <div>
+      <div className="flex justify-end mb-1">
+        <button onClick={() => setOrder(order === 'old' ? 'new' : 'old')}>
+          {order === 'old' ? '新しい順' : '古い順'}に切り替え
+        </button>
+      </div>
+      <div
+        ref={logRef}
+        className="h-52 overflow-y-auto bg-black border border-gray-600 p-3 font-mono rounded text-gray-100"
+      >
+        {ordered.map((line) => (
+          <LogLine key={parseLog(line).id} line={line} />
+        ))}
+      </div>
+      {showBanner && (
+        <div
+          className="fixed bottom-4 left-1/2 -translate-x-1/2 bg-blue-500 text-white px-4 py-2 rounded cursor-pointer"
+          onClick={handleBannerClick}
+        >
+          新しいログがあります
+        </div>
+      )}
+    </div>
+  )
+}

--- a/client/src/components/MainView.jsx
+++ b/client/src/components/MainView.jsx
@@ -1,23 +1,8 @@
-import React, { useEffect, useRef } from 'react'
+import React from 'react'
 import ConsultationArea from './ConsultationArea.jsx'
-
-function parseLog(line) {
-  if (typeof line === 'string') {
-    const m = line.match(/^\[(.*?)\]\s*(EVENT|SYSTEM):\s*(.*)$/)
-    if (m) return { time: m[1], type: m[2], text: m[3] }
-    return { time: '', type: 'EVENT', text: line }
-  }
-  return line
-}
+import LogList from './LogList.jsx'
 
 export default function MainView({ characters, onSelect, logs, trusts, addLog, updateTrust, updateLastConsultation }) {
-  const logRef = useRef(null)
-
-  useEffect(() => {
-    if (logRef.current) {
-      logRef.current.scrollTop = logRef.current.scrollHeight
-    }
-  }, [logs])
 
   return (
     <div>
@@ -47,20 +32,7 @@ export default function MainView({ characters, onSelect, logs, trusts, addLog, u
       />
       <section className="mb-6">
         <h2 className="text-sm text-gray-300 border-b border-gray-600 pb-1 mb-2">▼ ログ表示エリア (CLI風)</h2>
-        <div ref={logRef} className="h-52 overflow-y-auto bg-black border border-gray-600 p-3 font-mono rounded text-gray-100">
-          {logs.map((line, idx) => {
-            const { time, type, text } = parseLog(line)
-            const cls = type === 'SYSTEM'
-              ? 'text-orange-300 font-bold'
-              : 'text-blue-400 font-bold'
-            return (
-              <p key={idx} className="mb-1">
-                {time && <span className="text-gray-400 mr-1">[{time}]</span>}
-                <span className={cls}>{type}:</span> {text}
-              </p>
-            )
-          })}
-        </div>
+        <LogList logs={logs} />
       </section>
     </div>
   )


### PR DESCRIPTION
## 概要
- ログ表示部分を `LogList` コンポーネントとして分離しました
- 各ログにはタイピング風アニメーションを追加しました
- スクロール位置を監視し、新着ログが未読の場合に下部へ通知バナーを表示します
- 表示順を「古い順／新しい順」で切り替えられるボタンを追加しました

## 動作確認
- `npm run build` を実行しましたが依存パッケージが無いため失敗しました

------
https://chatgpt.com/codex/tasks/task_e_687a02d018588333969d517b56bc6ffc