### PR TITLE
Fix log filtering in CharacterStatus

### DIFF
--- a/client/src/components/CharacterStatus.jsx
+++ b/client/src/components/CharacterStatus.jsx
@@ -73,7 +73,7 @@ export default function CharacterStatus({
 
   // 対象キャラ名を含むログを抽出し、新しいものから5件表示
   const events = logs
-    .filter(l => l.includes(char.name))
+    .filter(l => (typeof l === 'string' ? l : l.text).includes(char.name))
     .slice(-5)
     .map(parseLog)
     .reverse()


### PR DESCRIPTION
## Summary
- handle both string and object logs when filtering by character name

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a05779aa083339bc2963c1766ba83