### PR TITLE
Add MBTI diagnosis to React client

### DIFF
--- a/client/src/components/ManagementRoom.jsx
+++ b/client/src/components/ManagementRoom.jsx
@@ -1,20 +1,5 @@
 import React, { useState, useEffect } from 'react'
-
-// 簡易MBTI計算用ヘルパー
-const calcMbti = (values, personality) => {
-  const sums = {
-    ei: values[0] + values[4] + values[8] + values[12],
-    sn: values[1] + values[5] + values[9] + values[13],
-    tf: values[2] + values[6] + values[10] + values[14],
-    jp: values[3] + values[7] + values[11] + values[15]
-  }
-  let r = ''
-  r += sums.ei <= 7 ? 'E' : sums.ei >= 9 ? 'I' : (personality.social >= 3 ? 'E' : 'I')
-  r += sums.sn <= 7 ? 'S' : sums.sn >= 9 ? 'N' : (personality.expressiveness >= 3 ? 'N' : 'S')
-  r += sums.tf <= 7 ? 'T' : sums.tf >= 9 ? 'F' : (personality.kindness >= 3 ? 'F' : 'T')
-  r += sums.jp <= 7 ? 'J' : sums.jp >= 9 ? 'P' : (personality.activity >= 3 ? 'J' : 'P')
-  return r
-}
+import { mbtiQuestions, mbtiDescriptions, mbtiTypes, calculateMbti } from '../lib/mbti.js'
 
 const defaultAffections = {
   'なし': 0,
@@ -25,10 +10,6 @@ const defaultAffections = {
   '家族': 50
 }
 
-const mbtiTypes = [
-  'INFP','INFJ','INTP','INTJ','ISFP','ISFJ','ISTP','ISTJ',
-  'ENFP','ENFJ','ENTP','ENTJ','ESFP','ESFJ','ESTP','ESTJ'
-]
 
 export default function ManagementRoom({
   characters,
@@ -115,7 +96,7 @@ export default function ManagementRoom({
       id,
       name,
       personality,
-      mbti: mbtiMode === 'diag' ? (mbtiResult || calcMbti(mbtiSliders, personality)) : mbtiManual,
+      mbti: mbtiMode === 'diag' ? (mbtiResult || calculateMbti(mbtiSliders, personality)) : mbtiManual,
       mbti_slider: mbtiMode === 'diag' ? mbtiSliders : [],
       talkStyle: { preset: talkPreset, firstPerson, suffix },
       activityPattern,
@@ -329,13 +310,15 @@ export default function ManagementRoom({
                   <p>各質問にスライダーで回答してください。</p>
                   {mbtiSliders.map((v,i)=> (
                     <div className="mb-1" key={i}>
-                      <label className="mr-2">Q{i+1}:</label>
+                      <label className="mr-2">Q{i+1}: {mbtiQuestions[i]}</label>
                       <input type="range" min="0" max="4" value={v} onChange={e=>setMbtiSliders(prev=>{
                         const arr=[...prev]; arr[i]=parseInt(e.target.value); return arr})} />
                     </div>
                   ))}
-                  <button type="button" onClick={()=>setMbtiResult(calcMbti(mbtiSliders, personality))}>診断する</button>
-                  {mbtiResult && <p className="mt-1">診断結果: {mbtiResult}</p>}
+                  <button type="button" onClick={()=>setMbtiResult(calculateMbti(mbtiSliders, personality))}>診断する</button>
+                  {mbtiResult && (
+                    <p className="mt-1">診断結果: {mbtiResult}<br />{mbtiDescriptions[mbtiResult]}</p>
+                  )}
                 </div>
               )}
             </div>

--- a/client/src/lib/mbti.js
+++ b/client/src/lib/mbti.js
@@ -1,0 +1,54 @@
+export const mbtiQuestions = [
+  '初対面の人とすぐ話せる ⇔ 少し様子を見る',
+  '話すときは具体的 ⇔ 抽象的',
+  '決断は論理で考える ⇔ 気持ちを重視する',
+  '計画通りに進めたい ⇔ 成り行きに任せたい',
+  'にぎやかな場が好き ⇔ 一人の時間が落ち着く',
+  '今の現実を大事にする ⇔ 未来や可能性を考える',
+  'はっきり意見を伝える ⇔ 相手の気持ちを優先',
+  '予定を立てるのが得意 ⇔ その場の流れで動く',
+  '話すことで元気になる ⇔ 話すと疲れる',
+  '実体験や事実をもとに話す ⇔ たとえ話が多い',
+  '事実を整理して判断 ⇔ 感情の動きに従う',
+  '物事をきっちり終わらせたい ⇔ とりあえず動きたい',
+  '大人数の中でも自分を出せる ⇔ 少人数の方が安心',
+  '現実的だと言われる ⇔ 空想的だと言われる',
+  '冷静だねと言われる ⇔ 優しいねと言われる',
+  '決断は早い方 ⇔ 保留にしがち'
+]
+
+export const mbtiDescriptions = {
+  INFP: '控えめだけど思慮深く、感受性豊かなタイプのようです。',
+  INFJ: '物静かですが、強い信念を内に秘めている理想主義者です。',
+  INTP: '知的な探求心が旺盛で、ユニークな視点を持つアイデアマンです。',
+  INTJ: '戦略的な思考が得意で、計画を立てて物事を進める完璧主義者です。',
+  ISFP: '柔軟な考え方を持ち、芸術的なセンスに優れた冒険家です。',
+  ISFJ: '献身的で、大切な人を守ろうとする心温かい擁護者です。',
+  ISTP: '大胆で実践的な思考を持ち、物事の仕組みを探求する職人です。',
+  ISTJ: '実直で責任感が強く、伝統や秩序を重んじる管理者です。',
+  ENFP: '情熱的で想像力豊か、常に新しい可能性を追い求める運動家です。',
+  ENFJ: 'カリスマ性と共感力を兼ね備え、人々を導く主人公タイプです。',
+  ENTP: '頭の回転が速く、知的な挑戦を好む、鋭い論客です。',
+  ENTJ: 'リーダーシップに優れ、大胆な決断力で道を切り開く指揮官です。',
+  ESFP: '陽気でエネルギッシュ、その場の注目を集めるエンターテイナーです。',
+  ESFJ: '社交的で思いやりがあり、人々をサポートすることに喜びを感じる領事官です。',
+  ESTP: '賢く、エネルギッシュで、リスクを恐れない起業家精神の持ち主です。',
+  ESTJ: '優れた管理能力を持ち、物事を着実に実行していく、頼れる幹部タイプです。'
+}
+
+export const mbtiTypes = Object.keys(mbtiDescriptions)
+
+export function calculateMbti(sliderValues, personality) {
+  const scores = {
+    ei: sliderValues[0] + sliderValues[4] + sliderValues[8] + sliderValues[12],
+    sn: sliderValues[1] + sliderValues[5] + sliderValues[9] + sliderValues[13],
+    tf: sliderValues[2] + sliderValues[6] + sliderValues[10] + sliderValues[14],
+    jp: sliderValues[3] + sliderValues[7] + sliderValues[11] + sliderValues[15]
+  }
+  let result = ''
+  result += scores.ei <= 7 ? 'E' : scores.ei >= 9 ? 'I' : (personality.social >= 3 ? 'E' : 'I')
+  result += scores.sn <= 7 ? 'S' : scores.sn >= 9 ? 'N' : (personality.expressiveness >= 3 ? 'N' : 'S')
+  result += scores.tf <= 7 ? 'T' : scores.tf >= 9 ? 'F' : (personality.kindness >= 3 ? 'F' : 'T')
+  result += scores.jp <= 7 ? 'J' : scores.jp >= 9 ? 'P' : (personality.activity >= 3 ? 'J' : 'P')
+  return result
+}


### PR DESCRIPTION
## Summary
- implement MBTI logic and question text in React client
- show MBTI result with descriptions in management room

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a14720da08333abc67b237c82d723