### PR TITLE
相談ログ表示タイミング修正

### DIFF
--- a/Code/js/consultation.js
+++ b/Code/js/consultation.js
@@ -96,7 +96,6 @@ export function createConsultation() {
     };
     char.lastConsultation = Date.now();
     state.consultations.push(event);
-    appendLog(`${char.name}がプレイヤーに相談しています…`);
     renderConsultations();
     event.timer = setTimeout(() => removeConsultation(event.id, false), 3600000);
 }
@@ -133,6 +132,7 @@ function openPopup(id) {
     const ev = state.consultations.find(e => e.id === id);
     if (!ev) return;
     const char = state.characters.find(c => c.id === ev.charId);
+    appendLog(`${char.name}がプレイヤーに相談しています…`);
     dom.consultationQuestion.textContent = `${char.name}「${ev.template.core_prompt}」`;
     dom.consultationAnswerArea.innerHTML = '';
     if (ev.template.form === 'choice') {

--- a/client/src/components/ConsultationArea.jsx
+++ b/client/src/components/ConsultationArea.jsx
@@ -38,7 +38,6 @@ export default function ConsultationArea({ characters, trusts, updateTrust, addL
         const timeout = setTimeout(() => {
           setConsultations(p => p.filter(c => c.id !== id))
         }, AUTO_INTERVAL_MS)
-        addLog(`${char.name}がプレイヤーに相談しています…`)
         updateLastConsultation(char.id)
         return [...prev, { id, char, template, timeout }]
       })
@@ -60,7 +59,6 @@ export default function ConsultationArea({ characters, trusts, updateTrust, addL
     }, AUTO_INTERVAL_MS)
     const c = { id, char, template, timeout }
     setConsultations(prev => [...prev, c])
-    addLog(`${char.name}がプレイヤーに相談しています…`)
     updateLastConsultation(char.id)
   }
 
@@ -68,6 +66,7 @@ export default function ConsultationArea({ characters, trusts, updateTrust, addL
     setCurrent(c)
     setSelected('')
     setAnswered(false)
+    addLog(`${c.char.name}がプレイヤーに相談しています…`)
   }
 
   // 回答を送信

--- a/client/src/components/ConsultationArea.jsx
+++ b/client/src/components/ConsultationArea.jsx
@@ -84,7 +84,6 @@ export default function ConsultationArea({ characters, trusts, updateTrust, addL
 
     updateTrust(current.char.id, delta)
     updateLastConsultation(current.char.id)
-    addLog(`${current.char.name}との相談が終了しました`)
     clearTimeout(current.timeout)
     setAnswered(true)
   }


### PR DESCRIPTION
## Summary
- 相談イベント生成時のログ出力を削除
- 対応ボタンを押した時点でログを出力するよう変更

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a51aee6b883339dccd02b6d490c8b