### PR TITLE
更新: 相談ポップアップのボタン改善

### DIFF
--- a/Code/css/layout.css
+++ b/Code/css/layout.css
@@ -90,6 +90,7 @@ h2 {
 .consultation-popup .popup-inner {
     background-color: #3d3d3d;
     padding: 20px;
+    padding-top: 36px;
     border-radius: 6px;
     width: 90%;
     max-width: 400px;
@@ -99,12 +100,7 @@ h2 {
 .consultation-popup .popup-close {
     position: absolute;
     top: 6px;
-    right: 8px;
-    background: none;
-    border: none;
-    color: #fff;
-    font-size: 20px;
-    cursor: pointer;
+    left: 8px;
 }
 
 /* ログ表示エリア (CLI風) - ここは黒を維持してメリハリをつけます */

--- a/Code/js/consultation.js
+++ b/Code/js/consultation.js
@@ -158,9 +158,10 @@ function openPopup(id) {
         input.type = 'text';
         input.id = 'consult-fill';
         input.placeholder = 'ここに入力';
-        dom.consultationAnswerArea.appendChild(input);
+    dom.consultationAnswerArea.appendChild(input);
     }
     dom.consultationSendButton.disabled = false;
+    dom.consultationSendButton.textContent = '決定';
     dom.consultationPopup.style.display = 'flex';
 }
 
@@ -182,6 +183,7 @@ function handleSendClick() {
     updateTrust(ev.charId, delta);
     dom.consultationAnswerArea.innerHTML = '<p>ありがとう！</p>';
     dom.consultationSendButton.disabled = true;
+    dom.consultationSendButton.textContent = '完了';
     answered = true;
 }
 

--- a/Code/main-view.html
+++ b/Code/main-view.html
@@ -14,7 +14,7 @@
         <button id="consultation-close-button" class="popup-close">×</button>
         <p id="consultation-question"></p>
         <div id="consultation-answer-area"></div>
-        <button id="consultation-send-button">送信する</button>
+        <button id="consultation-send-button">決定</button>
     </div>
 </div>
 

--- a/client/src/components/ConsultationArea.jsx
+++ b/client/src/components/ConsultationArea.jsx
@@ -112,8 +112,8 @@ export default function ConsultationArea({ characters, trusts, updateTrust, addL
 
       {current && (
         <div className="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-50">
-          <div className="bg-gray-700 p-4 rounded relative w-11/12 max-w-sm">
-            <button className="absolute top-1 right-2" onClick={closePopup}>×</button>
+          <div className="bg-gray-700 p-4 rounded relative w-11/12 max-w-sm pt-6">
+            <button className="absolute top-1 left-2 px-2 py-1" onClick={closePopup}>×</button>
             <p className="mb-2">{current.char.name}「{current.template.core_prompt}」</p>
             {current.template.form === 'choice' ? (
               <div className="mb-2">
@@ -139,7 +139,7 @@ export default function ConsultationArea({ characters, trusts, updateTrust, addL
                 placeholder="ここに入力"
               />
             )}
-            <button onClick={sendAnswer} disabled={answered}>送信する</button>
+            <button onClick={sendAnswer} disabled={answered}>{answered ? '完了' : '決定'}</button>
             {answered && <p className="mt-2">ありがとう！</p>}
           </div>
         </div>


### PR DESCRIPTION
## 概要
- 相談ポップアップの送信ボタンを「決定」に変更し、クリック後は「完了」と表示するようにしました
- 閉じる(×)ボタンの位置を左上に変更し、他のボタンと同じスタイルになるよう修正しました
- 旧HTML/CSS/JS 版にも同様の調整を反映しました

## テスト
- `npm run build` を実行しましたが `vite: not found` のためビルドできませんでした

------
https://chatgpt.com/codex/tasks/task_e_687a6cff0a8483338497e5052b53259f