### PR TITLE
Fix consultation popup completion

### DIFF
--- a/Code/js/consultation.js
+++ b/Code/js/consultation.js
@@ -167,6 +167,10 @@ function openPopup(id) {
 
 function handleSendClick() {
     if (currentId == null) return;
+    if (answered) {
+        closePopup();
+        return;
+    }
     const ev = state.consultations.find(e => e.id === currentId);
     if (!ev) return;
     let kind = 'neutral';
@@ -179,10 +183,8 @@ function handleSendClick() {
     if (kind === 'good') delta = Math.floor(Math.random() * 3) + 3; // +3〜+5
     else if (kind === 'neutral') delta = Math.floor(Math.random() * 3); // 0〜2
     else delta = -(Math.floor(Math.random() * 3) + 2); // -2〜-4
-    if (answered) return;
     updateTrust(ev.charId, delta);
     dom.consultationAnswerArea.innerHTML = '<p>ありがとう！</p>';
-    dom.consultationSendButton.disabled = true;
     dom.consultationSendButton.textContent = '完了';
     answered = true;
 }

--- a/client/src/components/ConsultationArea.jsx
+++ b/client/src/components/ConsultationArea.jsx
@@ -72,6 +72,10 @@ export default function ConsultationArea({ characters, trusts, updateTrust, addL
   // 回答を送信
   const sendAnswer = () => {
     if (!current) return
+    if (answered) {
+      closePopup()
+      return
+    }
     let kind = 'neutral'
     if (current.template.form === 'choice') {
       if (!selected) return
@@ -139,7 +143,7 @@ export default function ConsultationArea({ characters, trusts, updateTrust, addL
                 placeholder="ここに入力"
               />
             )}
-            <button onClick={sendAnswer} disabled={answered}>{answered ? '完了' : '決定'}</button>
+            <button onClick={answered ? closePopup : sendAnswer}>{answered ? '完了' : '決定'}</button>
             {answered && <p className="mt-2">ありがとう！</p>}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- allow the "完了" button in consultation popups to close the popup
- update JS and React implementations accordingly

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a738afb888333aee7891248c8f8dc