### PR TITLE
活動傾向を考慮したイベント抽選と状態変化

### DIFF
--- a/Code/data/time_modifiers.json
+++ b/Code/data/time_modifiers.json
@@ -1,0 +1,32 @@
+{
+  "globalTimeModifiers": {
+    "morning": 0.7,
+    "noon": 1.0,
+    "evening": 1.2,
+    "night": 1.1,
+    "midnight": 0.5
+  },
+  "personalTimeModifiers": {
+    "normal": {
+      "morning": 1.0,
+      "noon": 1.0,
+      "evening": 1.0,
+      "night": 1.0,
+      "midnight": 1.0
+    },
+    "morning": {
+      "morning": 1.3,
+      "noon": 1.1,
+      "evening": 1.0,
+      "night": 0.9,
+      "midnight": 0.7
+    },
+    "night": {
+      "morning": 0.7,
+      "noon": 0.9,
+      "evening": 1.0,
+      "night": 1.1,
+      "midnight": 1.3
+    }
+  }
+}

--- a/Code/js/app-init.js
+++ b/Code/js/app-init.js
@@ -9,6 +9,7 @@ import { loadState } from './storage.js';
 import { state } from './state.js';
 import { renderSavedLogs } from './logger.js';
 import { loadConsultationTemplates, startConsultationScheduler, renderConsultations } from './consultation.js';
+import { loadTimeModifiers, updateCharacterConditions } from './time-utils.js';
 
 const EVENT_INTERVAL_MS = 1800000; // 30分に1回
 const EVENT_PROBABILITY = 0.7; // 70%
@@ -23,6 +24,7 @@ function updateDateTime() {
     const month = String(now.getMonth() + 1).padStart(2, '0');
     const day = String(now.getDate()).padStart(2, '0');
     dom.dateElement.textContent = `${year}/${month}/${day}`;
+    updateCharacterConditions();
 }
 
 function startEventScheduler() {
@@ -48,10 +50,12 @@ export async function initializeApp() {
     }
     await loadEmotionLabelTable();
     await loadMoodTables();
+    await loadTimeModifiers();
     await loadConsultationTemplates();
     setupEventListeners();
     setInterval(updateDateTime, 1000);
     updateDateTime();
+    updateCharacterConditions();
     startEventScheduler();
     startConsultationScheduler();
     renderCharacters();

--- a/Code/js/event-system.js
+++ b/Code/js/event-system.js
@@ -4,6 +4,7 @@ import { drawMood } from './mood.js';
 import { appendLog } from './logger.js';
 import { drawEmotionChange } from './emotion-label.js';
 import { addReportEvent, addReportChange } from './report-utils.js';
+import { getTimeWeight } from './time-utils.js';
 
 // イベント種別ごとの基礎好感度値
 const baseAffection = {
@@ -23,13 +24,14 @@ const moodAffectionModifier = {
 };
 
 function getRandomPair() {
-    if (state.characters.length < 2) return null;
-    const idx1 = Math.floor(Math.random() * state.characters.length);
+    const activeChars = state.characters.filter(c => c.condition !== '就寝中' && c.condition !== '風邪');
+    if (activeChars.length < 2) return null;
+    const idx1 = Math.floor(Math.random() * activeChars.length);
     let idx2 = idx1;
     while (idx2 === idx1) {
-        idx2 = Math.floor(Math.random() * state.characters.length);
+        idx2 = Math.floor(Math.random() * activeChars.length);
     }
-    return [state.characters[idx1], state.characters[idx2]];
+    return [activeChars[idx1], activeChars[idx2]];
 }
 
 function updateAffection(from, to, delta) {
@@ -49,6 +51,10 @@ export function triggerRandomEvent() {
     const pair = getRandomPair();
     if (!pair) return;
     const [a, b] = pair;
+    const weightA = getTimeWeight(a.activityPattern);
+    const weightB = getTimeWeight(b.activityPattern);
+    const chance = Math.min(1, weightA * weightB);
+    if (Math.random() > chance) return;
     const types = ['挨拶', '雑談', '思い出し会話', '二人きりの時間'];
     const type = types[Math.floor(Math.random() * types.length)];
     let desc = '';

--- a/Code/js/time-utils.js
+++ b/Code/js/time-utils.js
@@ -1,0 +1,47 @@
+import { state } from './state.js';
+
+let globalTimeModifiers = {};
+let personalTimeModifiers = {};
+
+export async function loadTimeModifiers() {
+    const res = await fetch('./data/time_modifiers.json');
+    const data = await res.json();
+    globalTimeModifiers = data.globalTimeModifiers;
+    personalTimeModifiers = data.personalTimeModifiers;
+}
+
+export function getTimeSlot(date = new Date()) {
+    const h = date.getHours();
+    if (h >= 5 && h <= 10) return 'morning';
+    if (h >= 11 && h <= 15) return 'noon';
+    if (h >= 16 && h <= 18) return 'evening';
+    if (h >= 19 && h <= 23) return 'night';
+    return 'midnight';
+}
+
+export function getTimeWeight(activityPattern) {
+    const slot = getTimeSlot();
+    const global = globalTimeModifiers[slot] || 1.0;
+    const personal = (personalTimeModifiers[activityPattern] || personalTimeModifiers.normal || {})[slot] || 1.0;
+    return global * personal;
+}
+
+function isSleeping(activityPattern, hour) {
+    switch (activityPattern) {
+        case 'morning':
+            return hour >= 22 || hour < 5;
+        case 'night':
+            return hour >= 2 && hour < 8;
+        default:
+            return hour >= 0 && hour < 6;
+    }
+}
+
+export function updateCharacterConditions() {
+    const now = new Date();
+    const hour = now.getHours();
+    state.characters.forEach(c => {
+        const asleep = isSleeping(c.activityPattern, hour);
+        c.condition = asleep ? '就寝中' : '活動中';
+    });
+}


### PR DESCRIPTION
## Summary
- 時間帯補正テーブル `time_modifiers.json` を追加
- 活動傾向と時間帯を扱う `time-utils.js` を新規作成
- アプリ初期化処理で時間帯データ読み込みと状態更新を実施
- イベント抽選に活動傾向の補正を反映し、就寝中・風邪中のキャラを除外

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687a74fd92788333805fd78d561bf3dc