### PR TITLE
ログ表示エリアの改良

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -66,6 +66,7 @@ const initialState = {
   ],
   consultations: [], // 進行中の相談イベント
   logs: [],          // CLI 風ログ
+  readLogCount: 0,
   reports: {},       // 日報履歴
 }
 
@@ -124,6 +125,10 @@ export default function App() {
         c.id === charId ? { ...c, lastConsultation: now } : c
       )
     }))
+  }
+
+  const updateReadLogCount = (count) => {
+    setState(prev => ({ ...prev, readLogCount: count }))
   }
 
   // localStorageから読み込み
@@ -314,11 +319,13 @@ export default function App() {
         <MainView
           characters={state.characters}
           logs={state.logs}
-          trusts={state.trusts}
+          readLogCount={state.readLogCount}
           onSelect={showStatus}
           addLog={addLog}
           updateTrust={updateTrust}
+          updateReadLogCount={updateReadLogCount}
           updateLastConsultation={updateLastConsultation}
+          trusts={state.trusts}
         />
       )}
       {view === 'management' && (

--- a/client/src/components/LogList.jsx
+++ b/client/src/components/LogList.jsx
@@ -33,7 +33,7 @@ function LogLine({ line }) {
   )
 }
 
-export default function LogList({ logs = [] }) {
+export default function LogList({ logs = [], readLogCount = 0, updateReadLogCount }) {
   const logRef = useRef(null)
   const [order, setOrder] = useState('old')
   const [showBanner, setShowBanner] = useState(false)
@@ -45,9 +45,11 @@ export default function LogList({ logs = [] }) {
     if (order === 'old') {
       const bottom = div.scrollTop + div.clientHeight >= div.scrollHeight - 5
       setShowBanner(!bottom)
+      if (bottom && updateReadLogCount) updateReadLogCount(logs.length)
     } else {
       const top = div.scrollTop <= 5
       setShowBanner(!top)
+      if (top && updateReadLogCount) updateReadLogCount(logs.length)
     }
   }
 
@@ -61,10 +63,18 @@ export default function LogList({ logs = [] }) {
   useEffect(() => {
     const div = logRef.current
     if (!div) return
+    div.scrollTop = div.scrollHeight
+    if (updateReadLogCount) updateReadLogCount(logs.length)
+  }, [])
+
+  useEffect(() => {
+    const div = logRef.current
+    if (!div) return
     if (order === 'old') {
       const bottom = div.scrollTop + div.clientHeight >= div.scrollHeight - 5
       if (bottom) {
         div.scrollTop = div.scrollHeight
+        if (updateReadLogCount) updateReadLogCount(logs.length)
       } else if (prevLen.current !== logs.length) {
         setShowBanner(true)
       }
@@ -72,6 +82,7 @@ export default function LogList({ logs = [] }) {
       const top = div.scrollTop <= 5
       if (top) {
         div.scrollTop = 0
+        if (updateReadLogCount) updateReadLogCount(logs.length)
       } else if (prevLen.current !== logs.length) {
         setShowBanner(true)
       }
@@ -79,7 +90,10 @@ export default function LogList({ logs = [] }) {
     prevLen.current = logs.length
   }, [logs, order])
 
-  const ordered = order === 'old' ? logs : [...logs].slice().reverse()
+  const readLogs = logs.slice(Math.max(0, readLogCount - 20), readLogCount)
+  const unreadLogs = logs.slice(readLogCount)
+  const displayed = [...readLogs, ...unreadLogs]
+  const ordered = order === 'old' ? displayed : [...displayed].slice().reverse()
 
   const handleBannerClick = () => {
     const div = logRef.current
@@ -101,7 +115,7 @@ export default function LogList({ logs = [] }) {
       </div>
       <div
         ref={logRef}
-        className="h-52 overflow-y-auto bg-black border border-gray-600 p-3 font-mono rounded text-gray-100"
+        className="h-[26rem] overflow-y-auto bg-black border border-gray-600 p-3 font-mono rounded text-gray-100"
       >
         {ordered.map((line) => (
           <LogLine key={parseLog(line).id} line={line} />

--- a/client/src/components/MainView.jsx
+++ b/client/src/components/MainView.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import ConsultationArea from './ConsultationArea.jsx'
 import LogList from './LogList.jsx'
 
-export default function MainView({ characters, onSelect, logs, trusts, addLog, updateTrust, updateLastConsultation }) {
+export default function MainView({ characters, onSelect, logs, readLogCount, updateReadLogCount, trusts, addLog, updateTrust, updateLastConsultation }) {
 
   return (
     <div>
@@ -31,8 +31,8 @@ export default function MainView({ characters, onSelect, logs, trusts, addLog, u
         updateLastConsultation={updateLastConsultation}
       />
       <section className="mb-6">
-        <h2 className="text-sm text-gray-300 border-b border-gray-600 pb-1 mb-2">▼ ログ表示エリア (CLI風)</h2>
-        <LogList logs={logs} />
+        <h2 className="text-sm text-gray-300 border-b border-gray-600 pb-1 mb-2">▼ ログ</h2>
+        <LogList logs={logs} readLogCount={readLogCount} updateReadLogCount={updateReadLogCount} />
       </section>
     </div>
   )

--- a/client/src/lib/storage.js
+++ b/client/src/lib/storage.js
@@ -27,6 +27,7 @@ export function loadStateFromLocal() {
       return l
     })
     parsed.reports = parsed.reports || {}
+    parsed.readLogCount = parsed.readLogCount || 0
     return parsed
   } catch (e) {
     console.error('保存データの読み込みに失敗しました', e)


### PR DESCRIPTION
## Summary
- ログの既読行数を保存する状態を追加
- ログ一覧の高さを倍に拡大
- 既読20行＋未読全表示に調整し、自動スクロールを追加
- 表示見出しを「ログ」に変更

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e154fad1883338eebef70461b2793