### PR TITLE
Implement confession event

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -131,6 +131,29 @@ export default function App() {
     setState(prev => ({ ...prev, readLogCount: count }))
   }
 
+  // 関係ラベルを更新
+  const updateRelationship = (idA, idB, label) => {
+    setState(prev => {
+      const pair = [idA, idB].sort()
+      const next = [...prev.relationships]
+      const idx = next.findIndex(r => r.pair[0] === pair[0] && r.pair[1] === pair[1])
+      if (idx >= 0) next[idx] = { pair, label }
+      else next.push({ pair, label })
+      return { ...prev, relationships: next }
+    })
+  }
+
+  // 感情ラベルを更新
+  const updateEmotion = (from, to, label) => {
+    setState(prev => {
+      const next = [...prev.emotions]
+      const idx = next.findIndex(e => e.from === from && e.to === to)
+      if (idx >= 0) next[idx] = { from, to, label }
+      else next.push({ from, to, label })
+      return { ...prev, emotions: next }
+    })
+  }
+
   // localStorageから読み込み
   useEffect(() => {
     const saved = loadStateFromLocal()
@@ -326,6 +349,11 @@ export default function App() {
           updateReadLogCount={updateReadLogCount}
           updateLastConsultation={updateLastConsultation}
           trusts={state.trusts}
+          relationships={state.relationships}
+          emotions={state.emotions}
+          affections={state.affections}
+          updateRelationship={updateRelationship}
+          updateEmotion={updateEmotion}
         />
       )}
       {view === 'management' && (

--- a/client/src/components/MainView.jsx
+++ b/client/src/components/MainView.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import ConsultationArea from './ConsultationArea.jsx'
 import LogList from './LogList.jsx'
 
-export default function MainView({ characters, onSelect, logs, readLogCount, updateReadLogCount, trusts, addLog, updateTrust, updateLastConsultation }) {
+export default function MainView({ characters, onSelect, logs, readLogCount, updateReadLogCount, trusts, addLog, updateTrust, updateLastConsultation, relationships, emotions, affections, updateRelationship, updateEmotion }) {
 
   return (
     <div>
@@ -29,6 +29,11 @@ export default function MainView({ characters, onSelect, logs, readLogCount, upd
         updateTrust={updateTrust}
         addLog={addLog}
         updateLastConsultation={updateLastConsultation}
+        relationships={relationships}
+        emotions={emotions}
+        affections={affections}
+        updateRelationship={updateRelationship}
+        updateEmotion={updateEmotion}
       />
       <section className="mb-6">
         <h2 className="text-sm text-gray-300 border-b border-gray-600 pb-1 mb-2">▼ ログ</h2>


### PR DESCRIPTION
## Summary
- add relationship and emotion update helpers in App
- pass relationship and emotion data to MainView and ConsultationArea
- support confession events with player guidance

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e1fae3540833393a32bef9620e830