### PR TITLE
Fix affection bar container tags

### DIFF
--- a/client/src/components/RelationItem.jsx
+++ b/client/src/components/RelationItem.jsx
@@ -30,16 +30,16 @@ export default function RelationItem({ charName, relation, onOpen }) {
       </summary>
       <div className="mt-2 ml-2 text-sm">
         <p>[{charName} → {relation.otherName}]</p>
-        <p className="flex items-center mb-1">
+        <div className="flex items-center mb-1">
           <span className="mr-1">好感度:</span>
           <AffectionBar score={relation.affectionTo} />
-        </p>
+        </div>
         <p>呼び方：{relation.nicknameTo ? `「${relation.nicknameTo}」` : '―'}</p>
         <p className="mt-2">[{relation.otherName} → {charName}]</p>
-        <p className="flex items-center mb-1">
+        <div className="flex items-center mb-1">
           <span className="mr-1">好感度:</span>
           <AffectionBar score={relation.affectionFrom} />
-        </p>
+        </div>
         <p>呼び方：{relation.nicknameFrom ? `「${relation.nicknameFrom}」` : '―'}</p>
       </div>
     </details>


### PR DESCRIPTION
## Summary
- fix layout tags in `RelationItem` to eliminate invalid DOM structure warnings

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e2639db9c8333856df8efc163dea7