### PR TITLE
Initialize event tables before scheduler

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import { triggerRandomEvent } from './lib/eventSystem.js'
+import { triggerRandomEvent, initEventSystem } from './lib/eventSystem.js'
 import {
   loadStateFromLocal,
   saveStateToLocal,
@@ -174,12 +174,20 @@ export default function App() {
 
   // 一定間隔でランダムイベントを発生させる
   useEffect(() => {
-    const timer = setInterval(() => {
-      if (Math.random() < EVENT_PROBABILITY) {
-        triggerRandomEvent(state, setState, addLog)
-      }
-    }, EVENT_INTERVAL_MS)
-    return () => clearInterval(timer)
+    let timer
+    const startScheduler = async () => {
+      // テーブル読み込み完了を待ってからスケジュール開始
+      await initEventSystem()
+      timer = setInterval(() => {
+        if (Math.random() < EVENT_PROBABILITY) {
+          triggerRandomEvent(state, setState, addLog)
+        }
+      }, EVENT_INTERVAL_MS)
+    }
+    startScheduler()
+    return () => {
+      if (timer) clearInterval(timer)
+    }
   }, [])
 
   // 日次で好感度の経過日数を評価

--- a/client/src/lib/eventSystem.js
+++ b/client/src/lib/eventSystem.js
@@ -4,9 +4,14 @@ import { drawEmotionChange, loadEmotionLabelTable, getEmotionLabel } from './emo
 import { addReportEvent, addReportChange } from './reportUtils.js'
 import { getTimeWeight } from './timeUtils.js'
 
-// テーブルを事前読み込み
-loadMoodTables()
-loadEmotionLabelTable()
+// 初期化処理: ムードテーブルと感情ラベルテーブルの読み込み
+export async function initEventSystem() {
+  // 並列で読み込んだ後に完了を返す
+  await Promise.all([
+    loadMoodTables(),
+    loadEmotionLabelTable()
+  ])
+}
 
 // イベント種別ごとの基本好感度変化量
 const baseAffection = {


### PR DESCRIPTION
## Summary
- add `initEventSystem` to load mood and emotion label tables via Promise
- start event scheduler after `initEventSystem` finishes

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f150195d08333b847034b2f1fba1e