### PR TITLE
Add GPT conversation generation

### DIFF
--- a/client/src/gpt/generateConversation.js
+++ b/client/src/gpt/generateConversation.js
@@ -1,0 +1,16 @@
+import { generateDialogue } from './generateDialogue.js'
+import { buildPrompt } from '../prompt/promptBuilder.js'
+
+/**
+ * イベント種別に合わせたプロンプトを生成し、GPT から会話文を取得します。
+ * @param {string} eventType - イベントの種類
+ * @param {Object} charA - キャラクターA
+ * @param {Object} charB - キャラクターB
+ * @param {Object} context - 関係性や感情などの追加情報
+ * @returns {Promise<string>} GPT が生成した会話文
+ */
+export async function generateConversation(eventType, charA, charB, context) {
+  const prompt = buildPrompt(eventType, charA, charB, context)
+  const text = await generateDialogue(prompt.core_prompt)
+  return text
+}


### PR DESCRIPTION
## Summary
- add `generateConversation` wrapper for GPT interaction
- call the wrapper from `triggerRandomEvent` to populate log details with generated dialogue

## Testing
- `npm install` *(fails: network access blocked)*
- `npm run build` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6881b6455ea083339a323be18f6f9091