### PR TITLE
Implement mood-based confession success

### DIFF
--- a/client/src/lib/confession.js
+++ b/client/src/lib/confession.js
@@ -1,0 +1,25 @@
+import { drawMood } from './mood.js'
+import { generateConversation } from '../gpt/generateConversation.js'
+
+export function getEventMood(state, idA, idB) {
+  return drawMood(state, idA, idB)
+}
+
+// 成功確率テーブル
+const successRateTable = {
+  2: 0.8,
+  1: 0.6,
+  0: 0.3,
+  '-1': 0.1,
+  '-2': 0.05,
+}
+
+export function evaluateConfessionResult(mood) {
+  const rate = successRateTable[mood] ?? 0.3
+  return { success: Math.random() < rate, rate }
+}
+
+export async function generateConfessionDialogue(success, charA, charB, context) {
+  const type = success ? '告白成功' : '告白失敗'
+  return generateConversation(type, charA, charB, context)
+}

--- a/client/src/prompt/promptBuilder.js
+++ b/client/src/prompt/promptBuilder.js
@@ -3,6 +3,8 @@ import { smalltalkTemplate } from './templates/smalltalkTemplate.js'
 import { memoryTalkTemplate } from './templates/memoryTalkTemplate.js'
 import { aloneTimeTemplate } from './templates/aloneTimeTemplate.js'
 import { becomeFriendsTemplate } from './templates/becomeFriendsTemplate.js'
+import { confessSuccessTemplate } from './templates/confessSuccessTemplate.js'
+import { confessFailureTemplate } from './templates/confessFailureTemplate.js'
 import { becomeBestFriendsTemplate } from './templates/becomeBestFriendsTemplate.js'
 import { getStyleModifiers } from './styleModifiers.js'
 
@@ -13,7 +15,9 @@ const templateMap = {
   "思い出し会話": memoryTalkTemplate,
   "二人きりの時間": aloneTimeTemplate,
   "友達になる": becomeFriendsTemplate,
-  "親友になる": becomeBestFriendsTemplate
+  "親友になる": becomeBestFriendsTemplate,
+  "告白成功": confessSuccessTemplate,
+  "告白失敗": confessFailureTemplate,
 }
 
 // 雰囲気数値をテキストに変換


### PR DESCRIPTION
## Summary
- introduce `confession.js` utility with mood handling and success judgement
- extend promptBuilder to support confession templates
- add mood draw and success calculation for confession events

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881d4ce4a1c83339348cdd075c428ab