### PR TITLE
Implement confession prompt generation

### DIFF
--- a/client/src/lib/confession.js
+++ b/client/src/lib/confession.js
@@ -1,5 +1,6 @@
 import { drawMood } from './mood.js'
-import { generateConversation } from '../gpt/generateConversation.js'
+import { generateDialogue } from '../gpt/generateDialogue.js'
+import { buildPrompt } from '../prompt/promptBuilder.js'
 
 export function getEventMood(state, idA, idB) {
   return drawMood(state, idA, idB)
@@ -19,7 +20,13 @@ export function evaluateConfessionResult(mood) {
   return { success: Math.random() < rate, rate }
 }
 
-export async function generateConfessionDialogue(success, charA, charB, context) {
+export function buildConfessionPrompt(success, charA, charB, context) {
   const type = success ? '告白成功' : '告白失敗'
-  return generateConversation(type, charA, charB, context)
+  return buildPrompt(type, charA, charB, context)
+}
+
+export async function generateConfessionDialogue(success, charA, charB, context) {
+  const prompt = buildConfessionPrompt(success, charA, charB, context)
+  const text = await generateDialogue(prompt.core_prompt)
+  return text
 }


### PR DESCRIPTION
## Summary
- add `buildConfessionPrompt` in `confession.js`
- generate prompts with confessSuccessTemplate or confessFailureTemplate
- produce dialogue with `generateDialogue`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6881dc80cd388333bf03f02744e68a13