### PR TITLE
Improve confession lines with GPT adjustments

### DIFF
--- a/client/src/gpt/adjustLine.js
+++ b/client/src/gpt/adjustLine.js
@@ -1,0 +1,26 @@
+import { generateDialogue } from './generateDialogue.js'
+import { getStyleModifiers } from '../prompt/styleModifiers.js'
+
+function buildAdjustmentPrompt(text, char) {
+  const talkPreset = char.talkStyle?.preset || ''
+  const modifiers = getStyleModifiers(char.personality || {})
+  return `以下のセリフを、指定されたキャラクターの性格に合った自然な口調に言い換えてください。
+
+# キャラクター情報
+- 名前: ${char.name}
+- 話し方プリセット: ${talkPreset}
+- style_modifiers: ${JSON.stringify(modifiers)}
+
+# セリフ
+${text}
+
+# 出力ルール
+- セリフの意味は保ちつつ、キャラクターが自然に言いそうな言い回しにしてください。
+- セリフのみを返してください（余計な説明文や名前は不要です）。`
+}
+
+export async function adjustLineByPersonality(text, char) {
+  const prompt = buildAdjustmentPrompt(text, char)
+  const adjusted = await generateDialogue(prompt)
+  return adjusted
+}


### PR DESCRIPTION
## Summary
- add `adjustLineByPersonality` helper to rewrite lines using GPT
- transform confession consultation text just before display
- adjust resolve messages when the player declines the confession

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881e1e32ee083339f01abf1d8be35b8