### PR TITLE
Add talk style and interests to GPT prompts

### DIFF
--- a/client/src/prompt/promptBuilder.js
+++ b/client/src/prompt/promptBuilder.js
@@ -73,15 +73,27 @@ export function buildPrompt(eventType, characterA, characterB, context) {
     .replaceAll('{timeSlot}', context.timeSlot)
     .replaceAll('{moodText}', moodText)
 
-  const styleModifiers = getStyleModifiers(characterA.personality)
-  core += `\n会話スタイルの特徴：${JSON.stringify(styleModifiers)}`
+  const styleModifiersA = getStyleModifiers(characterA.personality)
+  const styleModifiersB = getStyleModifiers(characterB.personality)
+  core += `\n${characterA.name}の会話スタイルの特徴：${JSON.stringify(styleModifiersA)}`
+  core += `\n${characterB.name}の会話スタイルの特徴：${JSON.stringify(styleModifiersB)}`
+
+  const talkA = characterA.talkStyle || {}
+  const talkB = characterB.talkStyle || {}
+  core += `\n${characterA.name}の話し方: プレセット「${talkA.preset || '不明'}」、一人称「${talkA.firstPerson || ''}」、語尾「${talkA.suffix || ''}」`
+  core += `\n${characterB.name}の話し方: プレセット「${talkB.preset || '不明'}」、一人称「${talkB.firstPerson || ''}」、語尾「${talkB.suffix || ''}」`
+
+  const interestsA = (characterA.interests || []).join('、') || '特になし'
+  const interestsB = (characterB.interests || []).join('、') || '特になし'
+  core += `\n${characterA.name}の興味関心: ${interestsA}`
+  core += `\n${characterB.name}の興味関心: ${interestsB}`
 
   return {
     core_prompt: core,
     event_type: eventType,
     time_slot: context.timeSlot,
     mood: moodText,
-    style_modifiers: styleModifiers
+    style_modifiers: styleModifiersA
   }
 }
 


### PR DESCRIPTION
## Summary
- include both characters' talk style presets, first-person pronouns and suffixes in prompts
- include interests information
- provide conversation style modifiers for each character

## Testing
- `npm install` *(fails: network access blocked)*
- `npm run build` *(fails: vite not found due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6882cb23ec848333b68e6f6a9b3681a9