### PR TITLE
Add age and gender fields

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -24,6 +24,8 @@ const initialState = {
     {
       id: 'char_001',
       name: '碧',
+      age: 17,
+      gender: '男性',
       personality: { social: 4, kindness: 3, stubbornness: 2, activity: 5, expressiveness: 4 },
       mbti: 'INFP',
       talkStyle: { preset: 'くだけた', firstPerson: '俺', suffix: '〜じゃん' },
@@ -35,6 +37,8 @@ const initialState = {
     {
       id: 'char_002',
       name: '彩花',
+      age: 17,
+      gender: '女性',
       personality: { social: 5, kindness: 4, stubbornness: 1, activity: 3, expressiveness: 5 },
       mbti: 'ESFJ',
       talkStyle: { preset: '丁寧', firstPerson: '私', suffix: '〜です' },
@@ -46,6 +50,8 @@ const initialState = {
     {
       id: 'char_003',
       name: '志音',
+      age: 16,
+      gender: '男性',
       personality: { social: 2, kindness: 5, stubbornness: 4, activity: 2, expressiveness: 2 },
       mbti: 'ISFP',
       talkStyle: { preset: 'くだけた', firstPerson: 'ボク', suffix: '〜だよ' },

--- a/client/src/components/CharacterStatus.jsx
+++ b/client/src/components/CharacterStatus.jsx
@@ -78,6 +78,8 @@ export default function CharacterStatus({
       <h2 className="text-sm text-gray-300 border-b border-gray-600 pb-1 mb-2">▼ ステータス</h2>
       <div className="basic-info mb-2">
         <p>名前: {char.name}</p>
+        <p>年齢: {char.age ?? '不明'}</p>
+        <p>性別: {char.gender || '不明'}</p>
         <p>MBTI: {char.mbti}</p>
         <p>話し方プリセット: {talk.preset || '未設定'}</p>
         <p>一人称: {talk.firstPerson || '未設定'}</p>

--- a/client/src/components/ManagementRoom.jsx
+++ b/client/src/components/ManagementRoom.jsx
@@ -25,6 +25,8 @@ export default function ManagementRoom({
   const [showForm, setShowForm] = useState(false)
   const [editingId, setEditingId] = useState(null)
   const [name, setName] = useState('')
+  const [age, setAge] = useState('')
+  const [gender, setGender] = useState('男性')
   const [personality, setPersonality] = useState(blankPersonality)
   const [talkPreset, setTalkPreset] = useState('丁寧')
   const [firstPerson, setFirstPerson] = useState('')
@@ -42,6 +44,8 @@ export default function ManagementRoom({
   const startEdit = (char) => {
     setEditingId(char.id)
     setName(char.name)
+    setAge(char.age || '')
+    setGender(char.gender || '男性')
     setPersonality(char.personality || blankPersonality)
     setTalkPreset(char.talkStyle?.preset || '丁寧')
     setFirstPerson(char.talkStyle?.firstPerson || '')
@@ -74,6 +78,8 @@ export default function ManagementRoom({
   const resetForm = () => {
     setEditingId(null)
     setName('')
+    setAge('')
+    setGender('男性')
     setPersonality(blankPersonality)
     setTalkPreset('丁寧')
     setFirstPerson('')
@@ -96,6 +102,8 @@ export default function ManagementRoom({
     const char = {
       id,
       name,
+      age: age ? parseInt(age) : undefined,
+      gender,
       personality,
       mbti: mbtiMode === 'diag' ? (mbtiResult || calculateMbti(mbtiSliders, personality)) : mbtiManual,
       mbti_slider: mbtiMode === 'diag' ? mbtiSliders : [],
@@ -207,6 +215,18 @@ export default function ManagementRoom({
           <div className="mb-2">
             <label className="mr-2">名前:</label>
             <input className="text-black" value={name} onChange={e=>setName(e.target.value)} required />
+          </div>
+          <div className="mb-2">
+            <label className="mr-2">年齢:</label>
+            <input type="number" className="text-black w-20" value={age} onChange={e=>setAge(e.target.value)} />
+          </div>
+          <div className="mb-2">
+            <label className="mr-2">性別:</label>
+            <select className="text-black" value={gender} onChange={e=>setGender(e.target.value)}>
+              <option value="男性">男性</option>
+              <option value="女性">女性</option>
+              <option value="その他">その他</option>
+            </select>
           </div>
           <h4>性格パラメータ (1-5)</h4>
           {Object.keys(personality).map(key => (

--- a/client/src/prompt/promptBuilder.js
+++ b/client/src/prompt/promptBuilder.js
@@ -63,6 +63,10 @@ export function buildPrompt(eventType, characterA, characterB, context) {
   let core = template
     .replaceAll('{characterA.name}', characterA.name)
     .replaceAll('{characterB.name}', characterB.name)
+    .replaceAll('{characterA.age}', characterA.age ?? '不明')
+    .replaceAll('{characterB.age}', characterB.age ?? '不明')
+    .replaceAll('{characterA.gender}', characterA.gender || '不明')
+    .replaceAll('{characterB.gender}', characterB.gender || '不明')
     .replaceAll('{mbtiA}', characterA.mbti || '不明')
     .replaceAll('{mbtiB}', characterB.mbti || '不明')
     .replaceAll('{personalityA}', personalityA)
@@ -104,6 +108,8 @@ if (
 ) {
   const sampleChar = {
     name: "ユウタ",
+    age: 18,
+    gender: "男性",
     mbti: "INFP",
     personality: {
       sociability: 4,

--- a/client/src/prompt/templates/aloneTimeTemplate.js
+++ b/client/src/prompt/templates/aloneTimeTemplate.js
@@ -2,8 +2,8 @@ export const aloneTimeTemplate = `
 以下のキャラクター同士が、周囲に誰もいない状況で、二人きりで過ごしています。
 時間帯は{timeSlot}、雰囲気は{moodText}です。
 
-- {characterA.name}：{personalityA}
-- {characterB.name}：{personalityB}
+- {characterA.name}（{characterA.age}歳・{characterA.gender}）：{personalityA}
+- {characterB.name}（{characterB.age}歳・{characterB.gender}）：{personalityB}
 - 関係：{relationLabel}
 - 感情：A→B: {emotionAtoB}、B→A: {emotionBtoA}
 

--- a/client/src/prompt/templates/becomeBestFriendsTemplate.js
+++ b/client/src/prompt/templates/becomeBestFriendsTemplate.js
@@ -2,8 +2,8 @@ export const becomeBestFriendsTemplate = `
 以下のキャラクター同士が、これまでの関係の中で特に大事な会話を交わし、強い友情を感じる場面を描写してください。
 時間帯は{timeSlot}、雰囲気は{moodText}です。
 
-- {characterA.name}：{personalityA}
-- {characterB.name}：{personalityB}
+- {characterA.name}（{characterA.age}歳・{characterA.gender}）：{personalityA}
+- {characterB.name}（{characterB.age}歳・{characterB.gender}）：{personalityB}
 - 関係：{relationLabel}（変化前は「友達」）
 - 感情：A→B: {emotionAtoB}、B→A: {emotionBtoA}
 

--- a/client/src/prompt/templates/becomeFriendsTemplate.js
+++ b/client/src/prompt/templates/becomeFriendsTemplate.js
@@ -2,8 +2,8 @@ export const becomeFriendsTemplate = `
 以下のキャラクター同士が、はじめてしっかりと会話を交わし、打ち解け始める様子を描写してください。
 時間帯は{timeSlot}、雰囲気は{moodText}です。
 
-- {characterA.name}：{personalityA}
-- {characterB.name}：{personalityB}
+- {characterA.name}（{characterA.age}歳・{characterA.gender}）：{personalityA}
+- {characterB.name}（{characterB.age}歳・{characterB.gender}）：{personalityB}
 - 関係：{relationLabel}（変化前は「認知」）
 - 感情：A→B: {emotionAtoB}、B→A: {emotionBtoA}
 

--- a/client/src/prompt/templates/confessFailureTemplate.js
+++ b/client/src/prompt/templates/confessFailureTemplate.js
@@ -2,8 +2,8 @@ export const confessFailureTemplate = `
 以下のキャラクターのうち、{characterA.name}が{characterB.name}に対して告白するが、恋人関係にはならず「気まずい」関係に変化する場面を描写してください。
 時間帯は{timeSlot}、雰囲気は{moodText}です。
 
-- {characterA.name}：{personalityA}
-- {characterB.name}：{personalityB}
+- {characterA.name}（{characterA.age}歳・{characterA.gender}）：{personalityA}
+- {characterB.name}（{characterB.age}歳・{characterB.gender}）：{personalityB}
 - 関係：{relationLabel}（変化前は「友達」）
 - 感情：A→B: {emotionAtoB}、B→A: {emotionBtoA}
 

--- a/client/src/prompt/templates/confessSuccessTemplate.js
+++ b/client/src/prompt/templates/confessSuccessTemplate.js
@@ -2,8 +2,8 @@ export const confessSuccessTemplate = `
 以下のキャラクターのうち、{characterA.name}が{characterB.name}に対して告白し、恋人関係になる場面を描写してください。
 時間帯は{timeSlot}、雰囲気は{moodText}です。
 
-- {characterA.name}：{personalityA}
-- {characterB.name}：{personalityB}
+- {characterA.name}（{characterA.age}歳・{characterA.gender}）：{personalityA}
+- {characterB.name}（{characterB.age}歳・{characterB.gender}）：{personalityB}
 - 関係：{relationLabel}（変化前は「友達」）
 - 感情：A→B: {emotionAtoB}、B→A: {emotionBtoA}
 

--- a/client/src/prompt/templates/getStyleModifiers.js
+++ b/client/src/prompt/templates/getStyleModifiers.js
@@ -2,8 +2,8 @@ export const aloneTimeTemplate = `
 以下のキャラクター同士が、周囲に誰もいない状況で、二人きりで過ごしています。
 時間帯は{timeSlot}、雰囲気は{moodText}です。
 
-- {characterA.name}：{personalityA}
-- {characterB.name}：{personalityB}
+- {characterA.name}（{characterA.age}歳・{characterA.gender}）：{personalityA}
+- {characterB.name}（{characterB.age}歳・{characterB.gender}）：{personalityB}
 - 関係：{relationLabel}
 - 感情：A→B: {emotionAtoB}、B→A: {emotionBtoA}
 

--- a/client/src/prompt/templates/greetingTemplate.js
+++ b/client/src/prompt/templates/greetingTemplate.js
@@ -2,8 +2,8 @@ export const greetingTemplate = `
 以下のキャラクター同士が、{timeSlot}の時間帯に軽く挨拶を交わしています。
 雰囲気は{moodText}です。
 
-- {characterA.name}：{personalityA}
-- {characterB.name}：{personalityB}
+- {characterA.name}（{characterA.age}歳・{characterA.gender}）：{personalityA}
+- {characterB.name}（{characterB.age}歳・{characterB.gender}）：{personalityB}
 - 関係：{relationLabel}
 - 感情：A→B: {emotionAtoB}、B→A: {emotionBtoA}
 

--- a/client/src/prompt/templates/memoryTalkTemplate.js
+++ b/client/src/prompt/templates/memoryTalkTemplate.js
@@ -2,8 +2,8 @@ export const memoryTalkTemplate = `
 以下のキャラクター同士が、過去に共有した思い出について自然に話しています。
 時間帯は{timeSlot}、雰囲気は{moodText}です。
 
-- {characterA.name}：{personalityA}
-- {characterB.name}：{personalityB}
+- {characterA.name}（{characterA.age}歳・{characterA.gender}）：{personalityA}
+- {characterB.name}（{characterB.age}歳・{characterB.gender}）：{personalityB}
 - 関係：{relationLabel}
 - 感情：A→B: {emotionAtoB}、B→A: {emotionBtoA}
 

--- a/client/src/prompt/templates/smalltalkTemplate.js
+++ b/client/src/prompt/templates/smalltalkTemplate.js
@@ -2,8 +2,8 @@ export const smalltalkTemplate = `
 以下のキャラクター同士が、{timeSlot}の時間帯に雑談をしています。
 雰囲気は{moodText}です。
 
-- {characterA.name}：{personalityA}
-- {characterB.name}：{personalityB}
+- {characterA.name}（{characterA.age}歳・{characterA.gender}）：{personalityA}
+- {characterB.name}（{characterB.age}歳・{characterB.gender}）：{personalityB}
 - 関係：{relationLabel}
 - 感情：A→B: {emotionAtoB}、B→A: {emotionBtoA}
 


### PR DESCRIPTION
## Summary
- 初期キャラクターに年齢・性別を追加
- 管理室フォームで年齢・性別を編集可能に変更
- ステータス画面で年齢・性別を表示
- プロンプト生成で年齢・性別をテンプレートへ組み込み
- 各テンプレートを修正し新しいプレースホルダーに対応

## Testing
- `npm run build` (失敗: vite が見つからず)


------
https://chatgpt.com/codex/tasks/task_e_6882eb1f117c83338d59dac5f9e1a06d