### PR TITLE
Fix duplicate initialization in storage

### DIFF
--- a/client/src/lib/storage.js
+++ b/client/src/lib/storage.js
@@ -65,7 +65,6 @@ export function importStateFromFile(file) {
           return l
         })
         data.reports = data.reports || {}
-        data.reports = data.reports || {}
         resolve(data)
       } catch (e) {
         reject(e)


### PR DESCRIPTION
## Summary
- remove duplicate default initialization of `data.reports` in `importStateFromFile`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68830a82915c8333905ab99bc88e5005