### PR TITLE
Modify consultation popup width and button placement

### DIFF
--- a/client/src/components/ConsultationArea.jsx
+++ b/client/src/components/ConsultationArea.jsx
@@ -322,7 +322,7 @@ export default function ConsultationArea({ characters, trusts, updateTrust, addL
 
       {current && (
         <div className="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-50">
-          <div className="bg-gray-700 p-4 rounded relative w-11/12 max-w-sm pt-12">
+          <div className="bg-gray-700 p-4 rounded relative w-[95%] pt-12">
             <button className="absolute top-2 right-2" onClick={closePopup}>×</button>
             <p className="mb-2">{current.char.name}「{current.template.core_prompt}」</p>
             {current.template.choices && current.template.choices.length > 0 ? (
@@ -368,9 +368,15 @@ export default function ConsultationArea({ characters, trusts, updateTrust, addL
                 placeholder="ここに入力"
               />
             )}
-            <button onClick={answered ? closePopup : sendAnswer}>{answered ? '完了' : '決定'}</button>
-            {answered && (
-              <p className="mt-2">{current.type === 'confession' ? 'じゃあ、いってきます' : replyText || 'ありがとう！'}</p>
+            {!answered ? (
+              <button onClick={sendAnswer}>決定</button>
+            ) : (
+              <>
+                <p className="mt-2">{current.type === 'confession' ? 'じゃあ、いってきます' : replyText || 'ありがとう！'}</p>
+                <div className="text-right mt-2">
+                  <button onClick={closePopup}>完了</button>
+                </div>
+              </>
             )}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- widen the consultation popup to use 95% of the screen width
- move the 完了 button below the reply text on the right

## Testing
- `npm run build` *(fails: vite not found)*


------
https://chatgpt.com/codex/tasks/task_e_688343847a3c83339fcdf955f145caab