### PR TITLE
Add date string to GPT prompts

### DIFF
--- a/client/src/components/ConsultationArea.jsx
+++ b/client/src/components/ConsultationArea.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react'
 
 import { adjustLineByPersonality } from '../gpt/adjustLine.js'
 
-import { getTimeSlot } from "../lib/timeUtils.js"
+import { getTimeSlot, getDateString } from "../lib/timeUtils.js"
 import { generateConsultation } from '../gpt/generateConsultation.js'
 import { getEventMood, evaluateConfessionResult, generateConfessionDialogue } from "../lib/confession.js"
 // characters: キャラクター一覧
@@ -269,6 +269,7 @@ export default function ConsultationArea({ characters, trusts, updateTrust, addL
             BtoA: affections.find(a => a.from === current.target.id && a.to === current.char.id)?.score || 0
           },
           timeSlot: getTimeSlot(),
+          date: getDateString(),
           mood: current.mood
         })
       } catch (err) {

--- a/client/src/lib/eventSystem.js
+++ b/client/src/lib/eventSystem.js
@@ -2,7 +2,7 @@
 import { drawMood, loadMoodTables } from './mood.js'
 import { drawEmotionChange, loadEmotionLabelTable, getEmotionLabel } from './emotionLabel.js'
 import { addReportEvent, addReportChange } from './reportUtils.js'
-import { getTimeWeight, getTimeSlot } from './timeUtils.js'
+import { getTimeWeight, getTimeSlot, getDateString } from './timeUtils.js'
 import { generateConversation } from '../gpt/generateConversation.js'
 
 // 初期化処理: ムードテーブルと感情ラベルテーブルの読み込み
@@ -124,6 +124,7 @@ export async function triggerRandomEvent(state, setState, addLog) {
         emotionLabels: { AtoB: emotionAB, BtoA: emotionBA },
         affectionScores: { AtoB: getAffection(state.affections, a.id, b.id), BtoA: getAffection(state.affections, b.id, a.id) },
         timeSlot: getTimeSlot(),
+        date: getDateString(),
         mood
       })
     } catch (err) {
@@ -156,6 +157,7 @@ export async function triggerRandomEvent(state, setState, addLog) {
         emotionLabels: { AtoB: emotionAB, BtoA: emotionBA },
         affectionScores: { AtoB: getAffection(state.affections, a.id, b.id), BtoA: getAffection(state.affections, b.id, a.id) },
         timeSlot: getTimeSlot(),
+        date: getDateString(),
         mood
       })
     } catch (err) {
@@ -205,6 +207,7 @@ export async function triggerRandomEvent(state, setState, addLog) {
       emotionLabels: { AtoB: emotionAB, BtoA: emotionBA },
       affectionScores: { AtoB: getAffection(state.affections, a.id, b.id), BtoA: getAffection(state.affections, b.id, a.id) },
       timeSlot: getTimeSlot(),
+      date: getDateString(),
       mood
     })
   } catch (err) {

--- a/client/src/lib/timeUtils.js
+++ b/client/src/lib/timeUtils.js
@@ -30,6 +30,14 @@ export function getTimeSlot(date = new Date()) {
   return 'midnight'
 }
 
+// YYYY/MM/DD 形式の日付文字列を返すヘルパー
+export function getDateString(date = new Date()) {
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  const d = String(date.getDate()).padStart(2, '0')
+  return `${y}/${m}/${d}`
+}
+
 export function getTimeWeight(activityPattern) {
   const slot = getTimeSlot()
   const pat = mapPattern(activityPattern)

--- a/client/src/prompt/promptBuilder.js
+++ b/client/src/prompt/promptBuilder.js
@@ -75,6 +75,7 @@ export function buildPrompt(eventType, characterA, characterB, context) {
     .replaceAll('{emotionAtoB}', context.emotionLabels?.AtoB)
     .replaceAll('{emotionBtoA}', context.emotionLabels?.BtoA)
     .replaceAll('{timeSlot}', context.timeSlot)
+    .replaceAll('{date}', context.date)
     .replaceAll('{moodText}', moodText)
 
   const styleModifiersA = getStyleModifiers(characterA.personality)
@@ -96,6 +97,7 @@ export function buildPrompt(eventType, characterA, characterB, context) {
     core_prompt: core,
     event_type: eventType,
     time_slot: context.timeSlot,
+    date: context.date,
     mood: moodText,
     style_modifiers: styleModifiersA
   }

--- a/client/src/prompt/templates/aloneTimeTemplate.js
+++ b/client/src/prompt/templates/aloneTimeTemplate.js
@@ -1,6 +1,6 @@
 export const aloneTimeTemplate = `
 以下のキャラクター同士が、周囲に誰もいない状況で、二人きりで過ごしています。
-時間帯は{timeSlot}、雰囲気は{moodText}です。
+日付は{date}、時間帯は{timeSlot}、雰囲気は{moodText}です。
 
 - {characterA.name}（{characterA.age}歳・{characterA.gender}）：{personalityA}
 - {characterB.name}（{characterB.age}歳・{characterB.gender}）：{personalityB}

--- a/client/src/prompt/templates/becomeBestFriendsTemplate.js
+++ b/client/src/prompt/templates/becomeBestFriendsTemplate.js
@@ -1,6 +1,6 @@
 export const becomeBestFriendsTemplate = `
 以下のキャラクター同士が、これまでの関係の中で特に大事な会話を交わし、強い友情を感じる場面を描写してください。
-時間帯は{timeSlot}、雰囲気は{moodText}です。
+日付は{date}、時間帯は{timeSlot}、雰囲気は{moodText}です。
 
 - {characterA.name}（{characterA.age}歳・{characterA.gender}）：{personalityA}
 - {characterB.name}（{characterB.age}歳・{characterB.gender}）：{personalityB}

--- a/client/src/prompt/templates/becomeFriendsTemplate.js
+++ b/client/src/prompt/templates/becomeFriendsTemplate.js
@@ -1,6 +1,6 @@
 export const becomeFriendsTemplate = `
 以下のキャラクター同士が、はじめてしっかりと会話を交わし、打ち解け始める様子を描写してください。
-時間帯は{timeSlot}、雰囲気は{moodText}です。
+日付は{date}、時間帯は{timeSlot}、雰囲気は{moodText}です。
 
 - {characterA.name}（{characterA.age}歳・{characterA.gender}）：{personalityA}
 - {characterB.name}（{characterB.age}歳・{characterB.gender}）：{personalityB}

--- a/client/src/prompt/templates/confessFailureTemplate.js
+++ b/client/src/prompt/templates/confessFailureTemplate.js
@@ -1,6 +1,6 @@
 export const confessFailureTemplate = `
 以下のキャラクターのうち、{characterA.name}が{characterB.name}に対して告白するが、恋人関係にはならず「気まずい」関係に変化する場面を描写してください。
-時間帯は{timeSlot}、雰囲気は{moodText}です。
+日付は{date}、時間帯は{timeSlot}、雰囲気は{moodText}です。
 
 - {characterA.name}（{characterA.age}歳・{characterA.gender}）：{personalityA}
 - {characterB.name}（{characterB.age}歳・{characterB.gender}）：{personalityB}

--- a/client/src/prompt/templates/confessSuccessTemplate.js
+++ b/client/src/prompt/templates/confessSuccessTemplate.js
@@ -1,6 +1,6 @@
 export const confessSuccessTemplate = `
 以下のキャラクターのうち、{characterA.name}が{characterB.name}に対して告白し、恋人関係になる場面を描写してください。
-時間帯は{timeSlot}、雰囲気は{moodText}です。
+日付は{date}、時間帯は{timeSlot}、雰囲気は{moodText}です。
 
 - {characterA.name}（{characterA.age}歳・{characterA.gender}）：{personalityA}
 - {characterB.name}（{characterB.age}歳・{characterB.gender}）：{personalityB}

--- a/client/src/prompt/templates/greetingTemplate.js
+++ b/client/src/prompt/templates/greetingTemplate.js
@@ -1,5 +1,5 @@
 export const greetingTemplate = `
-以下のキャラクター同士が、{timeSlot}の時間帯に軽く挨拶を交わしています。
+以下のキャラクター同士が、{date} の {timeSlot} の時間帯に軽く挨拶を交わしています。
 雰囲気は{moodText}です。
 
 - {characterA.name}（{characterA.age}歳・{characterA.gender}）：{personalityA}

--- a/client/src/prompt/templates/memoryTalkTemplate.js
+++ b/client/src/prompt/templates/memoryTalkTemplate.js
@@ -1,6 +1,6 @@
 export const memoryTalkTemplate = `
 以下のキャラクター同士が、過去に共有した思い出について自然に話しています。
-時間帯は{timeSlot}、雰囲気は{moodText}です。
+日付は{date}、時間帯は{timeSlot}、雰囲気は{moodText}です。
 
 - {characterA.name}（{characterA.age}歳・{characterA.gender}）：{personalityA}
 - {characterB.name}（{characterB.age}歳・{characterB.gender}）：{personalityB}

--- a/client/src/prompt/templates/smalltalkTemplate.js
+++ b/client/src/prompt/templates/smalltalkTemplate.js
@@ -1,5 +1,5 @@
 export const smalltalkTemplate = `
-以下のキャラクター同士が、{timeSlot}の時間帯に雑談をしています。
+以下のキャラクター同士が、{date} の {timeSlot} の時間帯に雑談をしています。
 雰囲気は{moodText}です。
 
 - {characterA.name}（{characterA.age}歳・{characterA.gender}）：{personalityA}


### PR DESCRIPTION
## Summary
- add `getDateString` helper for `YYYY/MM/DD`
- include current date in event and confession context
- update prompt builder and templates to accept `{date}`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68834c2c2e38833387952202274a786b