### PR TITLE
Add consultation log cleanup and answer log

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -99,6 +99,14 @@ export default function App() {
     return id
   }
 
+  // ログIDを指定して削除
+  const removeLog = (id) => {
+    setState(prev => ({
+      ...prev,
+      logs: prev.logs.filter(l => l.id !== id)
+    }))
+  }
+
   // 信頼度を変更
   // 信頼度を変更
   const updateTrust = (charId, delta) => {
@@ -371,6 +379,7 @@ export default function App() {
           readLogCount={state.readLogCount}
           onSelect={showStatus}
           addLog={addLog}
+          removeLog={removeLog}
           updateTrust={updateTrust}
           updateReadLogCount={updateReadLogCount}
           updateLastConsultation={updateLastConsultation}

--- a/client/src/components/MainView.jsx
+++ b/client/src/components/MainView.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import ConsultationArea from './ConsultationArea.jsx'
 import LogList from './LogList.jsx'
 
-export default function MainView({ characters, onSelect, logs, readLogCount, updateReadLogCount, trusts, addLog, updateTrust, updateLastConsultation, relationships, emotions, affections, updateRelationship, updateEmotion }) {
+export default function MainView({ characters, onSelect, logs, readLogCount, updateReadLogCount, trusts, addLog, removeLog, updateTrust, updateLastConsultation, relationships, emotions, affections, updateRelationship, updateEmotion }) {
 
   return (
     <div>
@@ -28,6 +28,7 @@ export default function MainView({ characters, onSelect, logs, readLogCount, upd
         trusts={trusts}
         updateTrust={updateTrust}
         addLog={addLog}
+        removeLog={removeLog}
         updateLastConsultation={updateLastConsultation}
         relationships={relationships}
         emotions={emotions}


### PR DESCRIPTION
## Summary
- add `removeLog` helper in `App.jsx`
- pass new prop through `MainView` to `ConsultationArea`
- store log id when consultation begins and remove if closed without answering
- show `相談に回答しました。` before processing answer results

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_688359e3921483339ee83e0d91387b76