### PR TITLE
Remove back-to-main buttons

### DIFF
--- a/client/src/components/CharacterStatus.jsx
+++ b/client/src/components/CharacterStatus.jsx
@@ -146,7 +146,6 @@ export default function CharacterStatus({
         )}
       </ul>
 
-      <button className="mt-4" onClick={onBack}>メインに戻る</button>
     </section>
   )
 }

--- a/client/src/components/DailyReport.jsx
+++ b/client/src/components/DailyReport.jsx
@@ -140,7 +140,6 @@ export default function DailyReport({ reports = {}, characters = [], onBack, onO
         )}
       </ul>
 
-      <button onClick={onBack}>メインに戻る</button>
     </section>
   )
 }

--- a/client/src/components/ManagementRoom.jsx
+++ b/client/src/components/ManagementRoom.jsx
@@ -385,7 +385,6 @@ export default function ManagementRoom({
           </li>
         ))}
       </ul>
-      <button className="mt-4" onClick={onBack}>メイン画面に戻る</button>
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- remove the bottom "メインに戻る" button from DailyReport
- remove the same button from CharacterStatus
- remove the bottom "メイン画面に戻る" button from ManagementRoom

## Testing
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68835cd2293c83338c24b423ad53cf63