### PR TITLE
Add nickname info to prompts

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -387,6 +387,7 @@ export default function App() {
           relationships={state.relationships}
           emotions={state.emotions}
           affections={state.affections}
+          nicknames={state.nicknames}
           updateRelationship={updateRelationship}
           updateEmotion={updateEmotion}
         />

--- a/client/src/components/ConsultationArea.jsx
+++ b/client/src/components/ConsultationArea.jsx
@@ -9,7 +9,7 @@ import { getEventMood, evaluateConfessionResult, generateConfessionDialogue } fr
 // trusts: 各キャラクターの信頼度
 // updateTrust: 信頼度を更新する関数
 // addLog: ログ追加用関数
-export default function ConsultationArea({ characters, trusts, updateTrust, addLog, removeLog, updateLastConsultation, relationships, emotions, affections, updateRelationship, updateEmotion }) {
+export default function ConsultationArea({ characters, trusts, updateTrust, addLog, removeLog, updateLastConsultation, relationships, emotions, affections, nicknames, updateRelationship, updateEmotion }) {
   const [confessTemplates, setConfessTemplates] = useState([])
   const [consultations, setConsultations] = useState([])
   const [current, setCurrent] = useState(null)
@@ -277,7 +277,11 @@ export default function ConsultationArea({ characters, trusts, updateTrust, addL
           },
           timeSlot: getTimeSlot(),
           date: getDateString(),
-          mood: current.mood
+          mood: current.mood,
+          nicknames: {
+            AtoB: nicknames.find(n => n.from === current.char.id && n.to === current.target.id)?.nickname,
+            BtoA: nicknames.find(n => n.from === current.target.id && n.to === current.char.id)?.nickname
+          }
         })
       } catch (err) {
         addLog(`会話生成エラー: ${err.message}`, 'SYSTEM')

--- a/client/src/components/MainView.jsx
+++ b/client/src/components/MainView.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import ConsultationArea from './ConsultationArea.jsx'
 import LogList from './LogList.jsx'
 
-export default function MainView({ characters, onSelect, logs, readLogCount, updateReadLogCount, trusts, addLog, removeLog, updateTrust, updateLastConsultation, relationships, emotions, affections, updateRelationship, updateEmotion }) {
+export default function MainView({ characters, onSelect, logs, readLogCount, updateReadLogCount, trusts, addLog, removeLog, updateTrust, updateLastConsultation, relationships, emotions, affections, nicknames, updateRelationship, updateEmotion }) {
 
   return (
     <div>
@@ -33,6 +33,7 @@ export default function MainView({ characters, onSelect, logs, readLogCount, upd
         relationships={relationships}
         emotions={emotions}
         affections={affections}
+        nicknames={nicknames}
         updateRelationship={updateRelationship}
         updateEmotion={updateEmotion}
       />

--- a/client/src/lib/eventSystem.js
+++ b/client/src/lib/eventSystem.js
@@ -58,6 +58,12 @@ function getAffection(list, from, to) {
   return rec ? rec.score : 0
 }
 
+// 呼び方を取得
+function getNickname(list, from, to) {
+  const rec = list.find(n => n.from === from && n.to === to)
+  return rec ? rec.nickname : ''
+}
+
 // キャラクター2名をランダムに選ぶ
 function getRandomPair(characters) {
   const active = characters.filter(
@@ -104,6 +110,8 @@ export async function triggerRandomEvent(state, setState, addLog) {
   const relation = getRelationLabel(state.relationships, a.id, b.id)
   const emotionAB = getEmotionLabel(state, a.id, b.id)
   const emotionBA = getEmotionLabel(state, b.id, a.id)
+  const nickAB = getNickname(state.nicknames, a.id, b.id)
+  const nickBA = getNickname(state.nicknames, b.id, a.id)
   const affAvg = (getAffection(state.affections, a.id, b.id) +
     getAffection(state.affections, b.id, a.id)) / 2
 
@@ -125,7 +133,8 @@ export async function triggerRandomEvent(state, setState, addLog) {
         affectionScores: { AtoB: getAffection(state.affections, a.id, b.id), BtoA: getAffection(state.affections, b.id, a.id) },
         timeSlot: getTimeSlot(),
         date: getDateString(),
-        mood
+        mood,
+        nicknames: { AtoB: nickAB, BtoA: nickBA }
       })
     } catch (err) {
       addLog(`会話生成エラー: ${err.message}`, 'SYSTEM')
@@ -158,7 +167,8 @@ export async function triggerRandomEvent(state, setState, addLog) {
         affectionScores: { AtoB: getAffection(state.affections, a.id, b.id), BtoA: getAffection(state.affections, b.id, a.id) },
         timeSlot: getTimeSlot(),
         date: getDateString(),
-        mood
+        mood,
+        nicknames: { AtoB: nickAB, BtoA: nickBA }
       })
     } catch (err) {
       addLog(`会話生成エラー: ${err.message}`, 'SYSTEM')
@@ -208,7 +218,8 @@ export async function triggerRandomEvent(state, setState, addLog) {
       affectionScores: { AtoB: getAffection(state.affections, a.id, b.id), BtoA: getAffection(state.affections, b.id, a.id) },
       timeSlot: getTimeSlot(),
       date: getDateString(),
-      mood
+      mood,
+      nicknames: { AtoB: nickAB, BtoA: nickBA }
     })
   } catch (err) {
     addLog(`会話生成エラー: ${err.message}`, 'SYSTEM')

--- a/client/src/prompt/promptBuilder.js
+++ b/client/src/prompt/promptBuilder.js
@@ -50,6 +50,7 @@ function formatPersonality(p = {}) {
  * @param {Object} characterA - キャラクターAの情報
  * @param {Object} characterB - キャラクターBの情報
  * @param {Object} context - 関係性や感情などの状況情報
+ * @param {Object} [context.nicknames] - A→B と B→A の呼び方
  * @returns {Object} プロンプトおよび補足情報
  */
 export function buildPrompt(eventType, characterA, characterB, context) {
@@ -77,6 +78,11 @@ export function buildPrompt(eventType, characterA, characterB, context) {
     .replaceAll('{timeSlot}', context.timeSlot)
     .replaceAll('{date}', context.date)
     .replaceAll('{moodText}', moodText)
+
+  // お互いの呼び方情報を追加
+  const nicknameAB = context.nicknames?.AtoB || characterB.name
+  const nicknameBA = context.nicknames?.BtoA || characterA.name
+  core += `\n呼び方: ${characterA.name}→「${nicknameAB}」、${characterB.name}→「${nicknameBA}」`
 
   const styleModifiersA = getStyleModifiers(characterA.personality)
   const styleModifiersB = getStyleModifiers(characterB.personality)


### PR DESCRIPTION
## Summary
- include nickname field in prompt builder
- provide nickname data in random events and confession dialogues
- plumb nicknames through MainView and ConsultationArea

## Testing
- `npm install` *(fails: network restricted)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68836d3032988333878fea0541c72156