### PR TITLE
Add loading state for consultations

### DIFF
--- a/client/src/components/ConsultationArea.jsx
+++ b/client/src/components/ConsultationArea.jsx
@@ -336,8 +336,7 @@ export default function ConsultationArea({ characters, trusts, updateTrust, addL
         {consultations.map(c => (
           <li key={c.id} className="flex justify-between bg-gray-700 rounded px-2 py-1 mb-1">
             <span>
-              ・{c.char.name}
-              {c.loading ? 'の相談を生成中...' : 'から相談があります'}
+              ・{c.loading ? '相談を受付中...' : `${c.char.name}から相談があります`}
             </span>
             <button onClick={() => openPopup(c)} disabled={c.loading}>対応する</button>
           </li>


### PR DESCRIPTION
## Summary
- show consultation placeholders immediately using loading flag
- update consultation data asynchronously
- disable opening popup while consultation generation is ongoing

## Testing
- `npm install` *(fails: unable to reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_6883822ef8e88333bdfa5360ee70b0c5