### PR TITLE
UI label update

### DIFF
--- a/client/src/components/ConsultationArea.jsx
+++ b/client/src/components/ConsultationArea.jsx
@@ -331,7 +331,8 @@ export default function ConsultationArea({ characters, trusts, updateTrust, addL
 
   return (
     <section className="mb-6">
-      <h2 className="text-sm text-gray-300 border-b border-gray-600 pb-1 mb-2">▼ 困りごと相談エリア</h2>
+      {/* 表示ラベルをより親しみやすい名称に変更 */}
+      <h2 className="text-sm text-gray-300 border-b border-gray-600 pb-1 mb-2">▼ 相談掲示板</h2>
       <ul className="mb-2 list-none">
         {consultations.map(c => (
           <li key={c.id} className="flex justify-between bg-gray-700 rounded px-2 py-1 mb-1">


### PR DESCRIPTION
## Summary
- rename the consultation area label to "相談掲示板" for clarity

## Testing
- `npm install` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6883886635188333b9b6efcb51e7dfdb