### PR TITLE
Add randomized sleep schedule

### DIFF
--- a/client/src/components/ManagementRoom.jsx
+++ b/client/src/components/ManagementRoom.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { mbtiQuestions, mbtiDescriptions, mbtiTypes, calculateMbti } from '../lib/mbti.js'
 import RangeSlider from './RangeSlider.jsx'
 import { speechTemplates } from '../lib/speechTemplates.js'
+import { drawSleepTimes } from '../lib/timeUtils.js'
 
 const defaultAffections = {
   'なし': 0,
@@ -110,6 +111,7 @@ export default function ManagementRoom({
     if (!name) return
     const id = editingId || 'char_' + Date.now()
     const existing = characters.find(c => c.id === id)
+    const times = existing ? { sleepStart: existing.sleepStart, sleepEnd: existing.sleepEnd } : drawSleepTimes(activityPattern)
     const char = {
       id,
       name,
@@ -122,6 +124,8 @@ export default function ManagementRoom({
       activityPattern,
       interests: interests.split(',').map(i => i.trim()).filter(i => i),
       condition: existing?.condition || '活動中',
+      sleepStart: times.sleepStart,
+      sleepEnd: times.sleepEnd,
       lastConsultation: existing?.lastConsultation || 0
     }
     const rels = []


### PR DESCRIPTION
## Summary
- implement sleep time drawing and condition judgement
- store random sleep times when creating characters
- update character condition each second and reroll daily at noon

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_688394a11adc833388bfb4c6f326ea55