### PR TITLE
Update UI labels from character to resident

### DIFF
--- a/client/src/components/CharacterStatus.jsx
+++ b/client/src/components/CharacterStatus.jsx
@@ -75,29 +75,29 @@ export default function CharacterStatus({
 
   return (
     <section id="character-status-view" className="mb-6">
-      <h2 className="text-sm text-gray-300 border-b border-gray-600 pb-1 mb-2">▼ ステータス</h2>
+      <h2 className="text-sm text-gray-300 border-b border-gray-600 pb-1 mb-2">▼ 情報</h2>
       <div className="basic-info mb-2">
         <p>名前: {char.name}</p>
         <p>年齢: {char.age ?? '不明'}</p>
         <p>性別: {char.gender || '不明'}</p>
         <p>MBTI: {char.mbti}</p>
-        <p>話し方テンプレート: {talk.template || '未設定'}</p>
-        <p>説明: {talk.description || '未設定'}</p>
+        <p>話し方: {talk.template || '未設定'}</p>
+        <p className="ml-4">特徴: {talk.description || '未設定'}</p>
         <p>現在状態: {char.condition || '活動中'}</p>
         <p>活動傾向: {char.activityPattern || '通常'}</p>
         <p>信頼度: {trust}</p>
         <p>興味関心: {(char.interests || []).length > 0 ? char.interests.join(', ') : 'なし'}</p>
       </div>
 
-      {/* 性格パラメータのバー表示 */}
-      <h3 className="text-sm text-gray-300 border-b border-gray-600 pb-1 mb-2">▼ 性格パラメータ</h3>
+      {/* 性格のバー表示 */}
+      <h3 className="text-sm text-gray-300 border-b border-gray-600 pb-1 mb-2">▼ 性格</h3>
       <ul className="mb-2 list-none p-0">
         <li className="mb-1">
           社交性:
           <progress value={p.social || 0} max="5" className="ml-2 w-40 h-2" />
         </li>
         <li className="mb-1">
-          気配り傾向:
+          気配り:
           <progress value={p.kindness || 0} max="5" className="ml-2 w-40 h-2" />
         </li>
         <li className="mb-1">

--- a/client/src/components/DailyReport.jsx
+++ b/client/src/components/DailyReport.jsx
@@ -77,7 +77,7 @@ export default function DailyReport({ reports = {}, characters = [], onBack, onO
         />
       </div>
       <div className="flex items-center mb-2 gap-2">
-        <label htmlFor="char-select" className="mr-1">キャラ:</label>
+        <label htmlFor="char-select" className="mr-1">住人:</label>
         <select
           id="char-select"
           className="text-black"

--- a/client/src/components/ManagementRoom.jsx
+++ b/client/src/components/ManagementRoom.jsx
@@ -221,12 +221,12 @@ export default function ManagementRoom({
   return (
     <section id="management-room" className="mb-6">
       <h2 className="text-sm text-gray-300 border-b border-gray-600 pb-1 mb-2">▼ 管理室</h2>
-      {!showForm && (
-        <button onClick={() => {setShowForm(true);resetForm()}}>+ キャラクター追加</button>
-      )}
+        {!showForm && (
+        <button onClick={() => {setShowForm(true);resetForm()}}>+ 新規住人登録</button>
+        )}
       {showForm && (
         <form onSubmit={handleSubmit} className="mb-4 border p-2">
-          <h3 className="mb-2">{editingId ? 'キャラクター編集' : 'キャラクター追加'}</h3>
+          <h3 className="mb-2">{editingId ? '住人情報編集' : '新規住人登録'}</h3>
           <div className="mb-2">
             <label className="mr-2">名前:</label>
             <input className="text-black" value={name} onChange={e=>setName(e.target.value)} required />
@@ -243,18 +243,18 @@ export default function ManagementRoom({
               <option value="その他">その他</option>
             </select>
           </div>
-          <h4>性格パラメータ (1-5)</h4>
+          <h4>性格 (1-5)</h4>
           {Object.keys(personality).map(key => (
             <div className="mb-2" key={key}>
               <label className="mr-2">{ key === 'social' ? '社交性' :
-                key === 'kindness' ? '気配り傾向' :
+                key === 'kindness' ? '気配り' :
                 key === 'stubbornness' ? '頑固さ' :
                 key === 'activity' ? '行動力' : '表現力'}: {personality[key]}</label>
               <RangeSlider min={1} max={5} value={personality[key]}
                 onChange={e=>setPersonality(prev=>({...prev,[key]:parseInt(e.target.value)}))} />
             </div>
           ))}
-          <h4>話し方テンプレート</h4>
+          <h4>話し方</h4>
           <div className="mb-2 flex items-center">
             <select className="text-black mr-2" value={talkTemplate} onChange={handleTemplateChange}>
               {speechTemplates.map(t => (
@@ -320,10 +320,10 @@ export default function ManagementRoom({
               <label className="mr-2">相手からの呼ばれ方:</label>
               <input className="text-black" value={relForm.nicknameFrom} onChange={e=>setRelForm(prev=>({...prev,nicknameFrom:e.target.value}))} />
             </div>
-            <button type="button" onClick={saveRelation}>この関係を保存</button>
+            <button type="button" onClick={saveRelation}>この関係を登録</button>
             <div className="mt-2">
               {Object.keys(tempRelations).length === 0 ? (
-                <p>設定済みの関係はありません。</p>
+                <p>特に関係を持っていません。</p>
               ) : (
                 <ul className="ml-4 list-none">
                   {Object.entries(tempRelations).map(([id,data])=> (
@@ -377,7 +377,7 @@ export default function ManagementRoom({
           <button type="button" className="ml-2" onClick={()=>{setShowForm(false);resetForm()}}>キャンセル</button>
         </form>
       )}
-      <h3 className="mb-2">▼ 既存キャラクター一覧</h3>
+      <h3 className="mb-2">▼ 住人一覧</h3>
       <ul className="list-none pl-4">
         {characters.map(c => (
           <li key={c.id} className="mb-1 flex justify-between items-center">


### PR DESCRIPTION
## Summary
- update ManagementRoom labels to reflect "住人"
- change DailyReport label from キャラ to 住人
- revise CharacterStatus labels (情報, 話し方, 特徴, 性格, 気配り)

## Testing
- `npm install` *(fails: internet disabled)*


------
https://chatgpt.com/codex/tasks/task_e_68845ebabbec8333b56f1f304f10c7a8