### PR TITLE
Update relation detail view

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -402,6 +402,7 @@ export default function App() {
           relationships={state.relationships}
           affections={state.affections}
           emotions={state.emotions}
+          nicknames={state.nicknames}
           logs={state.logs}
           onBack={() => {
             setCurrentPair(null)

--- a/client/src/components/ConsultationArea.jsx
+++ b/client/src/components/ConsultationArea.jsx
@@ -337,7 +337,7 @@ export default function ConsultationArea({ characters, trusts, updateTrust, addL
         {consultations.map(c => (
           <li key={c.id} className="flex justify-between bg-gray-700 rounded px-2 py-1 mb-1">
             <span>
-              ・{c.loading ? '相談を受付中...' : `${c.char.name}から相談があります`}
+              {c.loading ? '相談を受付中...' : `${c.char.name}から相談があります`}
             </span>
             <button onClick={() => openPopup(c)} disabled={c.loading}>対応する</button>
           </li>

--- a/client/src/components/LogDetail.jsx
+++ b/client/src/components/LogDetail.jsx
@@ -18,9 +18,11 @@ export default function LogDetail({ log = null, onBack }) {
         {log.time && <span className="mr-1">[{log.time}]</span>}
         {log.type}: {log.text}
       </p>
-      <pre className="whitespace-pre-wrap mb-4 bg-gray-700 p-2 rounded">
-        {log.detail || '詳細はありません'}
-      </pre>
+      {log.type !== 'SYSTEM' && (
+        <pre className="whitespace-pre-wrap mb-4 bg-gray-700 p-2 rounded">
+          {log.detail || '詳細はありません'}
+        </pre>
+      )}
       <button onClick={onBack}>戻る</button>
     </section>
   )

--- a/client/src/components/LogDetail.jsx
+++ b/client/src/components/LogDetail.jsx
@@ -4,7 +4,7 @@ export default function LogDetail({ log = null, onBack }) {
   if (!log) {
     return (
       <section className="mb-6">
-        <h2 className="text-sm text-gray-300 border-b border-gray-600 pb-1 mb-2">ログ詳細</h2>
+        <h2 className="text-sm text-gray-300 border-b border-gray-600 pb-1 mb-2">会話詳細</h2>
         <p>ログが見つかりません。</p>
         <button className="mt-4" onClick={onBack}>戻る</button>
       </section>
@@ -13,7 +13,7 @@ export default function LogDetail({ log = null, onBack }) {
 
   return (
     <section className="mb-6">
-      <h2 className="text-sm text-gray-300 border-b border-gray-600 pb-1 mb-2">ログ詳細</h2>
+      <h2 className="text-sm text-gray-300 border-b border-gray-600 pb-1 mb-2">会話詳細</h2>
       <p className="mb-2">
         {log.time && <span className="mr-1">[{log.time}]</span>}
         {log.type}: {log.text}

--- a/client/src/components/RelationDetail.jsx
+++ b/client/src/components/RelationDetail.jsx
@@ -63,7 +63,7 @@ export default function RelationDetail({
           <p>{charB.name}</p>
         </div>
       </div>
-      <p className="mb-2">関係ラベル: {label}</p>
+      <p className="mb-2">関係: {label}</p>
       <div className="grid grid-cols-2 gap-4 mb-4">
         <div>
           <p className="mb-1">[{charA.name} → {charB.name}]</p>

--- a/client/src/components/RelationDetail.jsx
+++ b/client/src/components/RelationDetail.jsx
@@ -21,6 +21,7 @@ export default function RelationDetail({
   relationships = [],
   affections = [],
   emotions = [],
+  nicknames = [],
   logs = [],
   onBack,
 }) {
@@ -33,6 +34,11 @@ export default function RelationDetail({
 
   const emotionAB = getEmotionLabel({ emotions }, charA.id, charB.id) || 'なし'
   const emotionBA = getEmotionLabel({ emotions }, charB.id, charA.id) || 'なし'
+
+  const nicknameAB =
+    nicknames.find(n => n.from === charA.id && n.to === charB.id)?.nickname || ''
+  const nicknameBA =
+    nicknames.find(n => n.from === charB.id && n.to === charA.id)?.nickname || ''
 
   // 両名が登場するログを抽出し新しいものから5件表示
   const histories = logs
@@ -47,14 +53,14 @@ export default function RelationDetail({
   return (
     <section className="mb-6">
       <h2 className="text-sm text-gray-300 border-b border-gray-600 pb-1 mb-2">
-        ▼ {charA.name}⇄{charB.name} 関係詳細
+        ▼ {charA.name} ⇄ {charB.name} 関係詳細
       </h2>
-      <div className="flex justify-between mb-2">
+      <div className="grid grid-cols-2 gap-4 mb-2">
         <div>
-          <p>キャラA: {charA.name}</p>
+          <p>{charA.name}</p>
         </div>
         <div>
-          <p>キャラB: {charB.name}</p>
+          <p>{charB.name}</p>
         </div>
       </div>
       <p className="mb-2">関係ラベル: {label}</p>
@@ -65,7 +71,8 @@ export default function RelationDetail({
             <span className="mr-1">好感度:</span>
             <AffectionBar score={affectionAB} />
           </p>
-          <p>感情ラベル: {emotionAB}</p>
+          <p>印象: {emotionAB}</p>
+          <p>呼び方: {nicknameAB ? `「${nicknameAB}」` : '―'}</p>
         </div>
         <div>
           <p className="mb-1">[{charB.name} → {charA.name}]</p>
@@ -73,11 +80,12 @@ export default function RelationDetail({
             <span className="mr-1">好感度:</span>
             <AffectionBar score={affectionBA} />
           </p>
-          <p>感情ラベル: {emotionBA}</p>
+          <p>印象: {emotionBA}</p>
+          <p>呼び方: {nicknameBA ? `「${nicknameBA}」` : '―'}</p>
         </div>
       </div>
-      <h3 className="text-sm text-gray-300 border-b border-gray-600 pb-1 mb-2">▼ 最近のやり取り履歴</h3>
-      <ul className="list-disc pl-4 mb-2">
+      <h3 className="text-sm text-gray-300 border-b border-gray-600 pb-1 mb-2">▼ 直近の関わり</h3>
+      <ul className="list-none pl-4 mb-2">
         {histories.length === 0 ? (
           <li>履歴なし</li>
         ) : (


### PR DESCRIPTION
## Summary
- show relation nicknames in the detail view
- align character name layout and add space around arrow
- rename emotion labels to "印象" and recent log section to "直近の関わり"
- remove bullet points from log list
- pass nickname data from `App` to relation detail

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884739bf7a4833385c5db54cebc1326