### PR TITLE
Add start screen with new game options

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -142,13 +142,15 @@ export default function App() {
 
   // localStorageから読み込み
   useEffect(() => {
-    if (isStarting) return
     const saved = loadStateFromLocal()
     if (saved) {
       setState(prev => ({ ...prev, ...saved }))
+      setIsStarting(false)
+      setInitialized(true)
+    } else {
+      setIsStarting(true)
     }
-    setInitialized(true)
-  }, [isStarting])
+  }, [])
 
   // 時間帯補正テーブルを読み込む
   useEffect(() => {
@@ -322,6 +324,7 @@ export default function App() {
       .then(loaded => {
         setState(prev => ({ ...prev, ...loaded }))
         setIsStarting(false)
+        setInitialized(true)
       })
       .catch(() => alert('セーブデータの読み込みに失敗しました'))
   }
@@ -331,6 +334,7 @@ export default function App() {
     setState(initialState)
     localStorage.removeItem('relation_sim_state')
     setIsStarting(false)
+    setInitialized(true)
   }
 
   // 開発用: 手動でランダムイベントを発生させる

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -13,6 +13,7 @@ import CharacterStatus from './components/CharacterStatus.jsx'
 import RelationDetail from './components/RelationDetail.jsx'
 import DailyReport from './components/DailyReport.jsx'
 import LogDetail from './components/LogDetail.jsx'
+import StartScreen from './components/StartScreen.jsx'
 import { addReportChange } from './lib/reportUtils.js'
 import {
   loadTimeModifiers,
@@ -41,6 +42,7 @@ const initialState = {
 
 export default function App() {
   const [view, setView] = useState('main')
+  const [isStarting, setIsStarting] = useState(true)
   const [state, setState] = useState(initialState)
   const stateRef = useRef(state)
   const [initialized, setInitialized] = useState(false)
@@ -140,12 +142,13 @@ export default function App() {
 
   // localStorageから読み込み
   useEffect(() => {
+    if (isStarting) return
     const saved = loadStateFromLocal()
     if (saved) {
       setState(prev => ({ ...prev, ...saved }))
     }
     setInitialized(true)
-  }, [])
+  }, [isStarting])
 
   // 時間帯補正テーブルを読み込む
   useEffect(() => {
@@ -313,6 +316,23 @@ export default function App() {
       .catch(() => alert('読み込みに失敗しました'))
   }
 
+  // スタート画面: セーブデータを読み込む
+  const handleLoadSaveData = (file) => {
+    importStateFromFile(file)
+      .then(loaded => {
+        setState(prev => ({ ...prev, ...loaded }))
+        setIsStarting(false)
+      })
+      .catch(() => alert('セーブデータの読み込みに失敗しました'))
+  }
+
+  // スタート画面: 新しく始める
+  const handleNewGame = () => {
+    setState(initialState)
+    localStorage.removeItem('relation_sim_state')
+    setIsStarting(false)
+  }
+
   // 開発用: 手動でランダムイベントを発生させる
   const handleDevEvent = async () => {
     try {
@@ -338,12 +358,16 @@ export default function App() {
 
   return (
     <div className="max-w-[50rem] mx-auto border border-gray-600 bg-panel p-4 rounded text-gray-100 min-h-screen">
-      <Header
-        onChangeView={setView}
-        onSave={handleExport}
-        onLoad={handleImport}
-        onDevEvent={handleDevEvent}
-      />
+      {isStarting ? (
+        <StartScreen onContinue={handleLoadSaveData} onNewGame={handleNewGame} />
+      ) : (
+        <>
+          <Header
+            onChangeView={setView}
+            onSave={handleExport}
+            onLoad={handleImport}
+            onDevEvent={handleDevEvent}
+          />
       {view === 'main' && (
         <MainView
           characters={state.characters}
@@ -426,6 +450,8 @@ export default function App() {
           log={state.logs.find(l => l.id === currentLogId)}
           onBack={() => setView('daily')}
         />
+      )}
+        </>
       )}
     </div>
   )

--- a/client/src/components/StartScreen.jsx
+++ b/client/src/components/StartScreen.jsx
@@ -11,7 +11,7 @@ export default function StartScreen({ onContinue, onNewGame }) {
   }
 
   return (
-    <div className="flex flex-col items-center gap-4 p-4">
+    <div className="min-h-[60vh] flex flex-col items-center justify-center gap-4 p-4">
       <h1 className="text-lg mb-4">セーブデータの選択</h1>
       <button onClick={() => fileInputRef.current?.click()}>続きからはじめる</button>
       <input

--- a/client/src/components/StartScreen.jsx
+++ b/client/src/components/StartScreen.jsx
@@ -1,0 +1,27 @@
+import React, { useRef } from 'react'
+
+// スタート画面。続きから始める・新しく始めるの選択肢を表示する
+export default function StartScreen({ onContinue, onNewGame }) {
+  const fileInputRef = useRef(null)
+
+  const handleSelectFile = (e) => {
+    const file = e.target.files?.[0]
+    if (file) onContinue(file)
+    e.target.value = ''
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-4 p-4">
+      <h1 className="text-lg mb-4">セーブデータの選択</h1>
+      <button onClick={() => fileInputRef.current?.click()}>続きからはじめる</button>
+      <input
+        type="file"
+        accept="application/json"
+        ref={fileInputRef}
+        onChange={handleSelectFile}
+        className="hidden"
+      />
+      <button onClick={onNewGame}>新しくはじめる</button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add `StartScreen` component for start menu
- manage game start with `isStarting` state in `App.jsx`
- add handlers to import save data or start new game
- show `StartScreen` before entering main view

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_688484c2605c8333a0b564c5f8d2de2d