### PR TITLE
Implement tutorial step 2 flow

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -14,6 +14,8 @@ import RelationDetail from './components/RelationDetail.jsx'
 import DailyReport from './components/DailyReport.jsx'
 import LogDetail from './components/LogDetail.jsx'
 import StartScreen from './components/StartScreen.jsx'
+import IntroScreen from './components/IntroScreen.jsx'
+import Popup from './components/Popup.jsx'
 import { addReportChange } from './lib/reportUtils.js'
 import {
   loadTimeModifiers,
@@ -51,6 +53,7 @@ export default function App() {
   const [currentChar, setCurrentChar] = useState(null)
   const [currentPair, setCurrentPair] = useState(null)
   const [currentLogId, setCurrentLogId] = useState(null)
+  const [popup, setPopup] = useState(null)
 
   // state の最新値を保持する参照
   useEffect(() => {
@@ -330,6 +333,16 @@ export default function App() {
       .catch(() => alert('読み込みに失敗しました'))
   }
 
+  // ポップアップ表示ヘルパー
+  const showPopup = (text, afterClose) => {
+    setPopup({ text, afterClose })
+  }
+
+  const closePopup = () => {
+    if (popup?.afterClose) popup.afterClose()
+    setPopup(null)
+  }
+
   // スタート画面: セーブデータを読み込む
   const handleLoadSaveData = (file) => {
     importStateFromFile(file)
@@ -347,11 +360,16 @@ export default function App() {
 
   // スタート画面: 新しく始める
   const handleNewGame = () => {
-    setState({ ...initialState, tutorialStep: 2 })
+    setState({ ...initialState, tutorialStep: 1 })
     localStorage.removeItem('relation_sim_state')
     setIsStarting(false)
     setInitialized(true)
+    setView('intro')
+  }
+
+  const handleIntroFinish = () => {
     setView('management')
+    setState(prev => ({ ...prev, tutorialStep: 2 }))
   }
 
   // 開発用: 手動でランダムイベントを発生させる
@@ -366,7 +384,7 @@ export default function App() {
   // チュートリアル用コールバック
   const handleFirstRegisterComplete = () => {
     if (state.tutorialStep === 2) {
-      alert(
+      showPopup(
         '一人目の住人が登録できました！\n' +
           '登録した住人は、こちらの住人一覧に表示されます。\n\n' +
           '次は、二人目の住人を登録してみましょう。\n' +
@@ -377,7 +395,7 @@ export default function App() {
 
   const handleSecondRegisterStart = () => {
     if (state.tutorialStep === 2) {
-      alert(
+      showPopup(
         '二人目以降の住人には、他の住人との関係性を予め設定することができます。\n\n' +
           'この「好感度」は、お互いについてどれだけ好ましく思っているかを示します。'
       )
@@ -386,14 +404,16 @@ export default function App() {
 
   const handleSecondRegisterComplete = () => {
     if (state.tutorialStep === 2) {
-      alert(
+      showPopup(
         '二人目の住人の登録が完了しました！\n\n' +
           'これで箱庭の暮らしが始まります。\n' +
           'どんな関係が生まれていくのか、ぜひ見守ってみてください。\n\n' +
-          'それでは、ホームへ進みましょう。'
+          'それでは、ホームへ進みましょう。',
+        () => {
+          setView('main')
+          setState(prev => ({ ...prev, tutorialStep: 3 }))
+        }
       )
-      setView('main')
-      setState(prev => ({ ...prev, tutorialStep: 3 }))
     }
   }
 
@@ -423,6 +443,9 @@ export default function App() {
             onLoad={handleImport}
             onDevEvent={handleDevEvent}
           />
+      {view === 'intro' && (
+        <IntroScreen onStart={handleIntroFinish} />
+      )}
       {view === 'main' && (
         <MainView
           characters={state.characters}
@@ -509,6 +532,9 @@ export default function App() {
           log={state.logs.find(l => l.id === currentLogId)}
           onBack={() => setView('daily')}
         />
+      )}
+      {popup && (
+        <Popup message={popup.text} onClose={closePopup} />
       )}
         </>
       )}

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -38,6 +38,8 @@ const initialState = {
   logs: [],          // CLI 風ログ
   readLogCount: 0,
   reports: {},       // 日報履歴
+  // チュートリアル進行度（2:住人登録チュートリアル、3以降:チュートリアル終了）
+  tutorialStep: 3,
 }
 
 export default function App() {
@@ -144,7 +146,11 @@ export default function App() {
   useEffect(() => {
     const saved = loadStateFromLocal()
     if (saved) {
-      setState(prev => ({ ...prev, ...saved }))
+      setState(prev => ({
+        ...prev,
+        ...saved,
+        tutorialStep: saved.tutorialStep ?? 3,
+      }))
       setIsStarting(false)
       setInitialized(true)
     } else {
@@ -314,7 +320,13 @@ export default function App() {
 
   const handleImport = (file) => {
     importStateFromFile(file)
-      .then(loaded => setState(prev => ({ ...prev, ...loaded })))
+      .then(loaded =>
+        setState(prev => ({
+          ...prev,
+          ...loaded,
+          tutorialStep: loaded.tutorialStep ?? 3,
+        }))
+      )
       .catch(() => alert('読み込みに失敗しました'))
   }
 
@@ -322,7 +334,11 @@ export default function App() {
   const handleLoadSaveData = (file) => {
     importStateFromFile(file)
       .then(loaded => {
-        setState(prev => ({ ...prev, ...loaded }))
+        setState(prev => ({
+          ...prev,
+          ...loaded,
+          tutorialStep: loaded.tutorialStep ?? 3,
+        }))
         setIsStarting(false)
         setInitialized(true)
       })
@@ -331,10 +347,11 @@ export default function App() {
 
   // スタート画面: 新しく始める
   const handleNewGame = () => {
-    setState(initialState)
+    setState({ ...initialState, tutorialStep: 2 })
     localStorage.removeItem('relation_sim_state')
     setIsStarting(false)
     setInitialized(true)
+    setView('management')
   }
 
   // 開発用: 手動でランダムイベントを発生させる
@@ -343,6 +360,40 @@ export default function App() {
       await triggerRandomEvent(stateRef.current, setState, addLog)
     } catch (err) {
       addLog(`イベント実行エラー: ${err.message}`, 'SYSTEM')
+    }
+  }
+
+  // チュートリアル用コールバック
+  const handleFirstRegisterComplete = () => {
+    if (state.tutorialStep === 2) {
+      alert(
+        '一人目の住人が登録できました！\n' +
+          '登録した住人は、こちらの住人一覧に表示されます。\n\n' +
+          '次は、二人目の住人を登録してみましょう。\n' +
+          '「新規住人登録」から追加することができます。'
+      )
+    }
+  }
+
+  const handleSecondRegisterStart = () => {
+    if (state.tutorialStep === 2) {
+      alert(
+        '二人目以降の住人には、他の住人との関係性を予め設定することができます。\n\n' +
+          'この「好感度」は、お互いについてどれだけ好ましく思っているかを示します。'
+      )
+    }
+  }
+
+  const handleSecondRegisterComplete = () => {
+    if (state.tutorialStep === 2) {
+      alert(
+        '二人目の住人の登録が完了しました！\n\n' +
+          'これで箱庭の暮らしが始まります。\n' +
+          'どんな関係が生まれていくのか、ぜひ見守ってみてください。\n\n' +
+          'それでは、ホームへ進みましょう。'
+      )
+      setView('main')
+      setState(prev => ({ ...prev, tutorialStep: 3 }))
     }
   }
 
@@ -398,6 +449,10 @@ export default function App() {
           relationships={state.relationships}
           nicknames={state.nicknames}
           affections={state.affections}
+          tutorialStep={state.tutorialStep}
+          onFirstRegisterComplete={handleFirstRegisterComplete}
+          onSecondRegisterStart={handleSecondRegisterStart}
+          onSecondRegisterComplete={handleSecondRegisterComplete}
           onSaveCharacter={saveCharacter}
           onDeleteCharacter={deleteCharacter}
           onBack={() => {

--- a/client/src/components/IntroScreen.jsx
+++ b/client/src/components/IntroScreen.jsx
@@ -1,0 +1,39 @@
+import React, { useState, useEffect } from 'react'
+
+export default function IntroScreen({ onStart }) {
+  const texts = [
+    'ようこそ、「Relation Sim」の世界へ。',
+    'ここは、あなたのキャラクターたちが暮らす小さな箱庭。彼らは日々の中で、少しずつ関係を築いていきます。',
+    'どんなつながりが生まれていくのかは、まだ誰にもわかりません。あなたは、その日常をそっと見守ることができます。',
+    'まずは、一人目の住人を迎え入れてみましょう。',
+  ]
+
+  const [visible, setVisible] = useState(0)
+
+  useEffect(() => {
+    if (visible < texts.length) {
+      const timer = setTimeout(() => setVisible(v => v + 1), 1500)
+      return () => clearTimeout(timer)
+    }
+  }, [visible])
+
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <div
+        className="bg-black bg-opacity-50 p-4 rounded text-xl"
+        style={{ writingMode: 'vertical-rl', textOrientation: 'upright' }}
+      >
+        {texts.slice(0, visible).map((t, i) => (
+          <p key={i} className="mb-4">
+            {t}
+          </p>
+        ))}
+        {visible === texts.length && (
+          <div className="mt-4 text-center">
+            <button onClick={onStart}>▶ はじめる</button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/client/src/components/IntroScreen.jsx
+++ b/client/src/components/IntroScreen.jsx
@@ -20,15 +20,13 @@ export default function IntroScreen({ onStart }) {
   }, [visible])
 
   return (
-    <div className="min-h-screen flex items-center justify-center">
-      <div className="bg-black bg-opacity-50 p-4 rounded text-xl w-full max-w-md">
-        {texts.map((t, i) => (
-          <p key={i} className={`mb-4 ${i < visible ? '' : 'invisible'}`}>{t}</p>
-        ))}
-        <div className={`mt-4 text-center ${visible === texts.length ? '' : 'invisible'}`}>
-          <button onClick={onStart}>▶ はじめる</button>
-        </div>
-      </div>
+    <div className="min-h-[60vh] flex flex-col items-center justify-center gap-4 p-4">
+      {texts.map((t, i) => (
+        <p key={i} className={`mb-4 ${i < visible ? '' : 'invisible'}`}>{t}</p>
+      ))}
+      {visible === texts.length && (
+        <button onClick={onStart}>▶ はじめる</button>
+      )}
     </div>
   )
 }

--- a/client/src/components/IntroScreen.jsx
+++ b/client/src/components/IntroScreen.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react'
 
 export default function IntroScreen({ onStart }) {
+  // 段落ごとに表示する文章一覧
   const texts = [
     'ようこそ、「Relation Sim」の世界へ。',
     'ここは、あなたのキャラクターたちが暮らす小さな箱庭。彼らは日々の中で、少しずつ関係を築いていきます。',
@@ -8,6 +9,7 @@ export default function IntroScreen({ onStart }) {
     'まずは、一人目の住人を迎え入れてみましょう。',
   ]
 
+  // 現在表示している段落数
   const [visible, setVisible] = useState(0)
 
   useEffect(() => {
@@ -19,20 +21,13 @@ export default function IntroScreen({ onStart }) {
 
   return (
     <div className="min-h-screen flex items-center justify-center">
-      <div
-        className="bg-black bg-opacity-50 p-4 rounded text-xl"
-        style={{ writingMode: 'vertical-rl', textOrientation: 'upright' }}
-      >
-        {texts.slice(0, visible).map((t, i) => (
-          <p key={i} className="mb-4">
-            {t}
-          </p>
+      <div className="bg-black bg-opacity-50 p-4 rounded text-xl w-full max-w-md">
+        {texts.map((t, i) => (
+          <p key={i} className={`mb-4 ${i < visible ? '' : 'invisible'}`}>{t}</p>
         ))}
-        {visible === texts.length && (
-          <div className="mt-4 text-center">
-            <button onClick={onStart}>▶ はじめる</button>
-          </div>
-        )}
+        <div className={`mt-4 text-center ${visible === texts.length ? '' : 'invisible'}`}>
+          <button onClick={onStart}>▶ はじめる</button>
+        </div>
       </div>
     </div>
   )

--- a/client/src/components/Popup.jsx
+++ b/client/src/components/Popup.jsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+export default function Popup({ message, onClose }) {
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-50">
+      <div className="bg-gray-700 p-4 rounded relative w-full max-w-[50rem]">
+        <p className="whitespace-pre-wrap mb-4">{message}</p>
+        <div className="text-right">
+          <button onClick={onClose}>OK</button>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add `tutorialStep` state to manage tutorial progress
- open Management view with registration form for new games
- guide the player through first and second resident registration
- hide relation section and resident list until needed

## Testing
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68848f0754108333b92bad0cdad38c94