### PR TITLE
Change add button label to register

### DIFF
--- a/Code/js/form-handler.js
+++ b/Code/js/form-handler.js
@@ -97,7 +97,7 @@ export function setupFormHandlers() {
         state.currentlyEditingId = null;
         resetFormState();
         dom.formTitle.textContent = 'キャラクター追加フォーム';
-        dom.submitButton.textContent = '追加する';
+        dom.submitButton.textContent = '登録する';
         dom.addCharacterForm.style.display = 'block';
         dom.showAddFormButton.style.display = 'none';
         dom.addCharacterForm.dataset.newId = 'char_' + Date.now();

--- a/Code/js/view-switcher.js
+++ b/Code/js/view-switcher.js
@@ -34,7 +34,7 @@ export function switchView(viewToShow) {
 
 export function resetFormState() {
     dom.formTitle.textContent = 'キャラクター追加フォーム';
-    dom.submitButton.textContent = '追加する';
+    dom.submitButton.textContent = '登録する';
     dom.addCharacterForm.reset();
     for (const key in dom.personalityValues) {
         dom.personalityValues[key].textContent = '3';

--- a/Code/management-view.html
+++ b/Code/management-view.html
@@ -244,7 +244,7 @@
                     </div>
                 </div>
 
-                <button type="submit">追加する</button>
+                <button type="submit">登録する</button>
             </form>
 
             <h3>▼ 既存キャラクター一覧</h3>

--- a/client/src/components/ManagementRoom.jsx
+++ b/client/src/components/ManagementRoom.jsx
@@ -415,7 +415,7 @@ export default function ManagementRoom({
               </select>
             </div>
           )}
-          <button type="submit" className="mt-2">{editingId ? '更新する' : '追加する'}</button>
+          <button type="submit" className="mt-2">{editingId ? '更新する' : '登録する'}</button>
           <button type="button" className="ml-2" onClick={()=>{setShowForm(false);resetForm()}}>キャンセル</button>
         </form>
       )}


### PR DESCRIPTION
## Summary
- change registration button text from `追加する` to `登録する`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884db7ce0388333aa4da2fad6e1054e