### PR TITLE
Add tutorial consultation feature

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -329,6 +329,7 @@ export default function App() {
 
   // 相談チュートリアル
   useEffect(() => {
+    let timer1, timer2
     if (
       view === 'main' &&
       state.tutorialStep === 4 &&
@@ -337,14 +338,26 @@ export default function App() {
     ) {
       tutorialFlags.current.step4 = true
       const character = state.characters[0]
-      const text =
-        `なにやら、${character.name} から相談が届いたようです。\n\n` +
-        'さっそく対応してみましょう。'
-      showPopup(text, () => {
+      timer1 = setTimeout(async () => {
+        let eventId = null
         if (consultRef.current) {
-          consultRef.current.addTutorialConsultation(character)
+          eventId = await consultRef.current.addTutorialConsultation(character, true)
         }
-      })
+        timer2 = setTimeout(() => {
+          const text =
+            `なにやら、${character.name} から相談が届いたようです。\n\n` +
+            'さっそく対応してみましょう。'
+          showPopup(text, () => {
+            if (consultRef.current && eventId !== null) {
+              consultRef.current.enableConsultation(eventId)
+            }
+          })
+        }, 1000)
+      }, 1000)
+    }
+    return () => {
+      if (timer1) clearTimeout(timer1)
+      if (timer2) clearTimeout(timer2)
     }
   }, [view, state.tutorialStep])
 
@@ -489,9 +502,11 @@ export default function App() {
       '信頼度が高まるほど、住人はより深い相談をしてくれるようになります。\n\n' +
       'また、相談は最大で3件まで表示され、\n' +
       '必要に応じて追加で受け付けることもできます。'
-    showPopup(message, () => {
-      setState(prev => ({ ...prev, tutorialStep: 5 }))
-    })
+    setTimeout(() => {
+      showPopup(message, () => {
+        setState(prev => ({ ...prev, tutorialStep: 5 }))
+      })
+    }, 3000)
   }
 
   const showStatus = (char) => {

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -49,12 +49,13 @@ export default function App() {
   const [showIntro, setShowIntro] = useState(false)
   const [state, setState] = useState(initialState)
   const stateRef = useRef(state)
+  const consultRef = useRef(null)
   const [initialized, setInitialized] = useState(false)
   const [currentChar, setCurrentChar] = useState(null)
   const [currentPair, setCurrentPair] = useState(null)
   const [currentLogId, setCurrentLogId] = useState(null)
   const [popup, setPopup] = useState(null)
-  const tutorialFlags = useRef({ step3: false })
+  const tutorialFlags = useRef({ step3: false, step4: false })
 
   // state の最新値を保持する参照
   useEffect(() => {
@@ -326,6 +327,27 @@ export default function App() {
     }
   }, [view, state.tutorialStep])
 
+  // 相談チュートリアル
+  useEffect(() => {
+    if (
+      view === 'main' &&
+      state.tutorialStep === 4 &&
+      !tutorialFlags.current.step4 &&
+      state.characters.length > 0
+    ) {
+      tutorialFlags.current.step4 = true
+      const character = state.characters[0]
+      const text =
+        `なにやら、${character.name} から相談が届いたようです。\n\n` +
+        'さっそく対応してみましょう。'
+      showPopup(text, () => {
+        if (consultRef.current) {
+          consultRef.current.addTutorialConsultation(character)
+        }
+      })
+    }
+  }, [view, state.tutorialStep])
+
   const saveCharacter = (char, rels = [], nicks = [], affs = []) => {
     setState(prev => {
       let characters = [...prev.characters]
@@ -459,6 +481,19 @@ export default function App() {
     }
   }
 
+  const handleConsultTutorialComplete = () => {
+    const message =
+      '相談に乗ることができましたね。\n\n' +
+      'うまく応じることができると、このように、\n' +
+      'その住人からの信頼度が少し上昇します。\n\n' +
+      '信頼度が高まるほど、住人はより深い相談をしてくれるようになります。\n\n' +
+      'また、相談は最大で3件まで表示され、\n' +
+      '必要に応じて追加で受け付けることもできます。'
+    showPopup(message, () => {
+      setState(prev => ({ ...prev, tutorialStep: 5 }))
+    })
+  }
+
   const showStatus = (char) => {
     setCurrentChar(char)
     setCurrentPair(null)
@@ -492,6 +527,8 @@ export default function App() {
           />
       {view === 'main' && (
         <MainView
+          consultRef={consultRef}
+          onTutorialComplete={handleConsultTutorialComplete}
           characters={state.characters}
           logs={state.logs}
           readLogCount={state.readLogCount}

--- a/client/src/components/ConsultationArea.jsx
+++ b/client/src/components/ConsultationArea.jsx
@@ -241,7 +241,7 @@ export default forwardRef(function ConsultationArea({ characters, trusts, update
         core_prompt: res.prompt,
         choices: res.choices || [],
         responses: res.responses || [],
-        trust_change: 1
+        trust_change: 5
       }
       setConsultations(prev =>
         prev.map(e => (e.id === id ? { ...e, template, loading: false } : e))

--- a/client/src/components/MainView.jsx
+++ b/client/src/components/MainView.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import ConsultationArea from './ConsultationArea.jsx'
 import LogList from './LogList.jsx'
 
-export default function MainView({ characters, onSelect, logs, readLogCount, updateReadLogCount, trusts, addLog, removeLog, updateTrust, updateLastConsultation, relationships, emotions, affections, nicknames, updateRelationship, updateEmotion }) {
+export default function MainView({ characters, onSelect, logs, readLogCount, updateReadLogCount, trusts, addLog, removeLog, updateTrust, updateLastConsultation, relationships, emotions, affections, nicknames, updateRelationship, updateEmotion, consultRef, onTutorialComplete }) {
 
   return (
     <div>
@@ -24,6 +24,7 @@ export default function MainView({ characters, onSelect, logs, readLogCount, upd
         </div>
       </section>
       <ConsultationArea
+        ref={consultRef}
         characters={characters}
         trusts={trusts}
         updateTrust={updateTrust}
@@ -36,6 +37,7 @@ export default function MainView({ characters, onSelect, logs, readLogCount, upd
         nicknames={nicknames}
         updateRelationship={updateRelationship}
         updateEmotion={updateEmotion}
+        onTutorialComplete={onTutorialComplete}
       />
       <section className="mb-2">
         <h2 className="text-sm text-gray-300 border-b border-gray-600 pb-1 mb-2">▼ ログ</h2>


### PR DESCRIPTION
## Summary
- allow `ConsultationArea` to expose `addTutorialConsultation`
- notify tutorial completion when popup closes
- support tutorial consultation from `App.jsx`
- enable `MainView` to forward ref and completion callback

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884ee98ffe883339860dd6b30c2e0b6