### PR TITLE
Add tutorial step 5 walkthrough

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -335,6 +335,7 @@ export default function App() {
 
   // ステータス確認チュートリアル
   useEffect(() => {
+    let timer
     if (
       view === 'main' &&
       state.tutorialStep === 5 &&
@@ -346,10 +347,14 @@ export default function App() {
         'この「みんなの様子」では、\n' +
         '住人たちの現在の様子を一覧で確認することができます。\n\n' +
         `試しに、${characterA.name} の様子を見てみましょう。`
-      showPopup(message, () => {
-        tutorialFlags.current.step5 = true
-        showStatus(characterA)
-      })
+      timer = setTimeout(() => {
+        showPopup(message, () => {
+          tutorialFlags.current.step5 = true
+        })
+      }, 3000)
+    }
+    return () => {
+      if (timer) clearTimeout(timer)
     }
   }, [view, state.tutorialStep])
 
@@ -549,7 +554,7 @@ export default function App() {
     setView('relation')
   }
 
-  // ステータス画面での説明と詳細誘導
+  // ステータス画面での説明
   useEffect(() => {
     if (
       view === 'status' &&
@@ -561,26 +566,18 @@ export default function App() {
       currentChar.id === state.characters[0].id
     ) {
       tutorialFlags.current.step5Status = true
-      const characterA = currentChar
-      const characterB = state.characters[1]
       const first =
         'ここでは、その住人について登録した情報や、\n' +
         '他の住人との関係、最近の出来事などを確認できます。\n\n' +
         '関係一覧では、表示されている住人を選ぶことで、\n' +
         'それぞれとの好感度や呼び方など、大まかな関係の情報を見ることができます。'
-      const second =
-        '「詳細」を選ぶと、さらに詳しい情報が見られます。\n\n' +
-        `試しに、${characterB.name} との関係を詳しく見てみましょう。`
-      showPopup(first, () => {
-        showPopup(second, () => {
-          showRelationDetail(characterA.id, characterB.id)
-        })
-      })
+      showPopup(first)
     }
   }, [view, state.tutorialStep, currentChar])
 
-  // 関係詳細画面での締め
+  // 関係詳細画面での説明
   useEffect(() => {
+    let timer
     if (
       view === 'relation' &&
       state.tutorialStep === 5 &&
@@ -595,13 +592,17 @@ export default function App() {
       const text1 =
         'この画面では、関係性や呼び方、好感度に加えて、\n' +
         '相手住人との直近の関わりや変化が表示されます。'
-      const text2 = 'では、ホームに戻りましょう。'
       showPopup(text1, () => {
-        showPopup(text2, () => {
-          setView('main')
-          setState(prev => ({ ...prev, tutorialStep: 6 }))
-        })
+        timer = setTimeout(() => {
+          showPopup('では、ホームに戻りましょう。', () => {
+            setView('main')
+            setState(prev => ({ ...prev, tutorialStep: 6 }))
+          })
+        }, 3000)
       })
+    }
+    return () => {
+      if (timer) clearTimeout(timer)
     }
   }, [view, state.tutorialStep, currentPair])
 

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -575,11 +575,13 @@ export default function App() {
       const second =
         '「詳細」を選ぶと、さらに詳しい情報が見られます。\n\n' +
         `試しに、${state.characters[1].name} との関係を詳しく見てみましょう。`
-      showPopup(first, () => {
-        timer = setTimeout(() => {
-          showPopup(second)
-        }, 5000)
-      })
+      timer = setTimeout(() => {
+        showPopup(first, () => {
+          timer = setTimeout(() => {
+            showPopup(second)
+          }, 4000)
+        })
+      }, 1000)
     }
     return () => {
       if (timer) clearTimeout(timer)
@@ -603,14 +605,16 @@ export default function App() {
       const text1 =
         'この画面では、関係性や呼び方、好感度に加えて、\n' +
         '相手住人との直近の関わりや変化が表示されます。'
-      showPopup(text1, () => {
-        timer = setTimeout(() => {
-          showPopup('では、ホームに戻りましょう。', () => {
-            setView('main')
-            setState(prev => ({ ...prev, tutorialStep: 6 }))
-          })
-        }, 3000)
-      })
+      timer = setTimeout(() => {
+        showPopup(text1, () => {
+          timer = setTimeout(() => {
+            showPopup('では、ホームに戻りましょう。', () => {
+              setView('main')
+              setState(prev => ({ ...prev, tutorialStep: 6 }))
+            })
+          }, 3000)
+        })
+      }, 1000)
     }
     return () => {
       if (timer) clearTimeout(timer)

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -55,7 +55,13 @@ export default function App() {
   const [currentPair, setCurrentPair] = useState(null)
   const [currentLogId, setCurrentLogId] = useState(null)
   const [popup, setPopup] = useState(null)
-  const tutorialFlags = useRef({ step3: false, step4: false })
+  const tutorialFlags = useRef({
+    step3: false,
+    step4: false,
+    step5: false,
+    step5Status: false,
+    step5Detail: false,
+  })
 
   // state の最新値を保持する参照
   useEffect(() => {
@@ -327,6 +333,26 @@ export default function App() {
     }
   }, [view, state.tutorialStep])
 
+  // ステータス確認チュートリアル
+  useEffect(() => {
+    if (
+      view === 'main' &&
+      state.tutorialStep === 5 &&
+      !tutorialFlags.current.step5 &&
+      state.characters.length >= 2
+    ) {
+      const characterA = state.characters[0]
+      const message =
+        'この「みんなの様子」では、\n' +
+        '住人たちの現在の様子を一覧で確認することができます。\n\n' +
+        `試しに、${characterA.name} の様子を見てみましょう。`
+      showPopup(message, () => {
+        tutorialFlags.current.step5 = true
+        showStatus(characterA)
+      })
+    }
+  }, [view, state.tutorialStep])
+
   // 相談チュートリアル
   useEffect(() => {
     let timer1, timer2
@@ -522,6 +548,62 @@ export default function App() {
     setCurrentPair({ a, b })
     setView('relation')
   }
+
+  // ステータス画面での説明と詳細誘導
+  useEffect(() => {
+    if (
+      view === 'status' &&
+      state.tutorialStep === 5 &&
+      tutorialFlags.current.step5 &&
+      !tutorialFlags.current.step5Status &&
+      currentChar &&
+      state.characters.length >= 2 &&
+      currentChar.id === state.characters[0].id
+    ) {
+      tutorialFlags.current.step5Status = true
+      const characterA = currentChar
+      const characterB = state.characters[1]
+      const first =
+        'ここでは、その住人について登録した情報や、\n' +
+        '他の住人との関係、最近の出来事などを確認できます。\n\n' +
+        '関係一覧では、表示されている住人を選ぶことで、\n' +
+        'それぞれとの好感度や呼び方など、大まかな関係の情報を見ることができます。'
+      const second =
+        '「詳細」を選ぶと、さらに詳しい情報が見られます。\n\n' +
+        `試しに、${characterB.name} との関係を詳しく見てみましょう。`
+      showPopup(first, () => {
+        showPopup(second, () => {
+          showRelationDetail(characterA.id, characterB.id)
+        })
+      })
+    }
+  }, [view, state.tutorialStep, currentChar])
+
+  // 関係詳細画面での締め
+  useEffect(() => {
+    if (
+      view === 'relation' &&
+      state.tutorialStep === 5 &&
+      tutorialFlags.current.step5Status &&
+      !tutorialFlags.current.step5Detail &&
+      currentPair &&
+      state.characters.length >= 2 &&
+      currentPair.a.id === state.characters[0].id &&
+      currentPair.b.id === state.characters[1].id
+    ) {
+      tutorialFlags.current.step5Detail = true
+      const text1 =
+        'この画面では、関係性や呼び方、好感度に加えて、\n' +
+        '相手住人との直近の関わりや変化が表示されます。'
+      const text2 = 'では、ホームに戻りましょう。'
+      showPopup(text1, () => {
+        showPopup(text2, () => {
+          setView('main')
+          setState(prev => ({ ...prev, tutorialStep: 6 }))
+        })
+      })
+    }
+  }, [view, state.tutorialStep, currentPair])
 
   return (
     <div className="max-w-[50rem] mx-auto border border-gray-600 bg-panel p-4 rounded text-gray-100 min-h-screen">

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -350,7 +350,6 @@ export default function App() {
       timer = setTimeout(() => {
         showPopup(message, () => {
           tutorialFlags.current.step5 = true
-          showStatus(characterA)
         })
       }, 3000)
     }
@@ -578,9 +577,7 @@ export default function App() {
         `試しに、${state.characters[1].name} との関係を詳しく見てみましょう。`
       showPopup(first, () => {
         timer = setTimeout(() => {
-          showPopup(second, () => {
-            showRelationDetail(state.characters[0].id, state.characters[1].id)
-          })
+          showPopup(second)
         }, 5000)
       })
     }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -350,6 +350,7 @@ export default function App() {
       timer = setTimeout(() => {
         showPopup(message, () => {
           tutorialFlags.current.step5 = true
+          showStatus(characterA)
         })
       }, 3000)
     }
@@ -556,6 +557,7 @@ export default function App() {
 
   // ステータス画面での説明
   useEffect(() => {
+    let timer
     if (
       view === 'status' &&
       state.tutorialStep === 5 &&
@@ -571,7 +573,19 @@ export default function App() {
         '他の住人との関係、最近の出来事などを確認できます。\n\n' +
         '関係一覧では、表示されている住人を選ぶことで、\n' +
         'それぞれとの好感度や呼び方など、大まかな関係の情報を見ることができます。'
-      showPopup(first)
+      const second =
+        '「詳細」を選ぶと、さらに詳しい情報が見られます。\n\n' +
+        `試しに、${state.characters[1].name} との関係を詳しく見てみましょう。`
+      showPopup(first, () => {
+        timer = setTimeout(() => {
+          showPopup(second, () => {
+            showRelationDetail(state.characters[0].id, state.characters[1].id)
+          })
+        }, 5000)
+      })
+    }
+    return () => {
+      if (timer) clearTimeout(timer)
     }
   }, [view, state.tutorialStep, currentChar])
 


### PR DESCRIPTION
## Summary
- extend tutorial flags to handle step 5
- guide the user on status and relation detail screens
- advance the tutorial to step 6 after viewing relation details

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_688505f5eb7883338f43a7136d070802