### PR TITLE
Implement cancel confirmation in ManagementRoom

### DIFF
--- a/client/src/components/ManagementRoom.jsx
+++ b/client/src/components/ManagementRoom.jsx
@@ -208,10 +208,10 @@ export default function ManagementRoom({
   }
 
   const handleCancel = () => {
-    if (window.confirm('登録をキャンセルしますか？')) {
-      setShowForm(false)
-      resetForm()
-    }
+    // 確認ダイアログで「いいえ」を選択したら何もしない
+    if (!window.confirm('登録をキャンセルしますか？')) return
+    setShowForm(false)
+    resetForm()
   }
 
   const handleRelTargetChange = (e) => {


### PR DESCRIPTION
## Summary
- modify `handleCancel` to stop when user declines
- confirm Cancel button uses this handler

## Testing
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885cbd1519083339bd8abe12dea2f0d