### PR TITLE
Add reset button

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -451,6 +451,17 @@ export default function App() {
       .catch(() => alert('読み込みに失敗しました'))
   }
 
+  // セーブデータを削除してスタート画面に戻る
+  const handleReset = () => {
+    if (window.confirm('本当にリセットしてよろしいですか？')) {
+      localStorage.removeItem('relation_sim_state')
+      setState(initialState)
+      setView('main')
+      setShowIntro(false)
+      setIsStarting(true)
+    }
+  }
+
   // ポップアップ表示ヘルパー
   const showPopup = (text, afterClose) => {
     setPopup({ text, afterClose })
@@ -497,14 +508,6 @@ export default function App() {
     }, 1000)
   }
 
-  // 開発用: 手動でランダムイベントを発生させる
-  const handleDevEvent = async () => {
-    try {
-      await triggerRandomEvent(stateRef.current, setState, addLog)
-    } catch (err) {
-      addLog(`イベント実行エラー: ${err.message}`, 'SYSTEM')
-    }
-  }
 
   // チュートリアル用コールバック
   const handleFirstRegisterComplete = () => {
@@ -659,7 +662,7 @@ export default function App() {
             onChangeView={setView}
             onSave={handleExport}
             onLoad={handleImport}
-            onDevEvent={handleDevEvent}
+            onReset={handleReset}
           />
       {view === 'main' && (
         <MainView

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState, useRef } from 'react'
 
-// 開発用イベント発生ボタンのハンドラ onDevEvent を追加
-export default function Header({ onChangeView, onSave, onLoad, onDevEvent }) {
+// ヘッダー。各画面への移動やセーブ/ロードなどを行う
+// リセットボタン用の onReset ハンドラを受け取る
+export default function Header({ onChangeView, onSave, onLoad, onReset }) {
   const [time, setTime] = useState('')
   const [date, setDate] = useState('')
   const fileInputRef = useRef(null)
@@ -23,8 +24,8 @@ export default function Header({ onChangeView, onSave, onLoad, onDevEvent }) {
       <button onClick={() => onChangeView('main')}>ホーム</button>
       <button onClick={() => onChangeView('management')}>管理室</button>
       <button onClick={() => onChangeView('daily')}>日報</button>
-      {/* 開発用: 手動でランダムイベントを発生させる */}
-      <button onClick={onDevEvent}>イベント発生（開発用）</button>
+      {/* セーブデータを初期化するリセットボタン */}
+      <button onClick={onReset}>リセット</button>
       <button onClick={onSave}>セーブ</button>
       <button onClick={() => fileInputRef.current?.click()}>ロード</button>
       <input


### PR DESCRIPTION
## Summary
- ヘッダーの開発用ボタンを削除
- 代わりにリセットボタンを追加
- リセット時に localStorage を削除して StartScreen に戻る

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885ce9885288333b6a316f0d0d3e1da