### PR TITLE
Add tone input and integrate into prompts

### DIFF
--- a/client/src/components/CharacterStatus.jsx
+++ b/client/src/components/CharacterStatus.jsx
@@ -83,6 +83,7 @@ export default function CharacterStatus({
         <p>MBTI: {char.mbti}</p>
         <p>話し方: {talk.template || '未設定'}</p>
         <p className="ml-4">特徴: {talk.description || '未設定'}</p>
+        <p>口調: {char.tone || '未設定'}</p>
         <p>現在状態: {char.condition || '活動中'}</p>
         <p>活動傾向: {char.activityPattern || '通常'}</p>
         <p>信頼度: {trust}</p>

--- a/client/src/components/ManagementRoom.jsx
+++ b/client/src/components/ManagementRoom.jsx
@@ -36,6 +36,7 @@ export default function ManagementRoom({
   const [personality, setPersonality] = useState(blankPersonality)
   const [talkTemplate, setTalkTemplate] = useState('優しい敬語')
   const [talkDesc, setTalkDesc] = useState('')
+  const [tone, setTone] = useState('')
   const [activityPattern, setActivityPattern] = useState('通常')
   const [interests, setInterests] = useState('')
   const [mbtiMode, setMbtiMode] = useState('diag')
@@ -85,6 +86,7 @@ export default function ManagementRoom({
     setTalkTemplate(tmpl)
     const found = speechTemplates.find(t => t.template === tmpl)
     setTalkDesc(char.talkStyle?.description ?? found?.description ?? '')
+    setTone(char.tone || '')
     setActivityPattern(char.activityPattern || '通常')
     setInterests((char.interests || []).join(', '))
     setMbtiManual(char.mbti || 'INFP')
@@ -118,6 +120,7 @@ export default function ManagementRoom({
     setPersonality(blankPersonality)
     setTalkTemplate('優しい敬語')
     setTalkDesc(speechTemplates.find(t=>t.template==='優しい敬語')?.description || '')
+    setTone('')
     setActivityPattern('通常')
     setInterests('')
     setMbtiMode('diag')
@@ -179,6 +182,7 @@ export default function ManagementRoom({
       mbti: mbtiMode === 'diag' ? (mbtiResult || calculateMbti(mbtiSliders, personality)) : mbtiManual,
       mbti_slider: mbtiMode === 'diag' ? mbtiSliders : [],
       talkStyle: { template: talkTemplate, description: talkDesc },
+      tone,
       activityPattern,
       interests: interests.split(',').map(i => i.trim()).filter(i => i),
       condition: existing?.condition || '活動中',
@@ -338,13 +342,17 @@ export default function ManagementRoom({
                 </option>
               ))}
             </select>
-            {talkTemplate === 'その他' ? (
-              <input className="text-black flex-1" value={talkDesc} onChange={e=>setTalkDesc(e.target.value)} placeholder="自由記述" />
-            ) : (
-              <span>{talkDesc}</span>
-            )}
-          </div>
-          <h4>活動傾向</h4>
+          {talkTemplate === 'その他' ? (
+            <input className="text-black flex-1" value={talkDesc} onChange={e=>setTalkDesc(e.target.value)} placeholder="自由記述" />
+          ) : (
+            <span>{talkDesc}</span>
+          )}
+        </div>
+        <div className="mb-2">
+          <label className="mr-2">口調:</label>
+          <input className="text-black" value={tone} onChange={e => setTone(e.target.value)} placeholder="例: 丁寧だが砕けた" />
+        </div>
+        <h4>活動傾向</h4>
           <div className="mb-2">
             <label className="mr-2"><input type="radio" name="act" value="通常" checked={activityPattern==='通常'} onChange={e=>setActivityPattern(e.target.value)} />通常</label>
             <label className="ml-4 mr-2"><input type="radio" name="act" value="朝型" checked={activityPattern==='朝型'} onChange={e=>setActivityPattern(e.target.value)} />朝型</label>

--- a/client/src/gpt/adjustLine.js
+++ b/client/src/gpt/adjustLine.js
@@ -9,6 +9,7 @@ function buildAdjustmentPrompt(text, char) {
 # キャラクター情報
 - 名前: ${char.name}
  - 話し方テンプレート: ${talkTemplate}
+- 口調: ${char.tone || ''}
 - style_modifiers: ${JSON.stringify(modifiers)}
 
 # セリフ

--- a/client/src/gpt/generateConsultation.js
+++ b/client/src/gpt/generateConsultation.js
@@ -10,6 +10,7 @@ function buildConsultPrompt(character, genre, level, trust) {
     `信頼度: ${trust}\n` +
     `ジャンル: ${genre}\n` +
     `レベル: ${level}\n` +
+    `口調: ${character.tone || ''}\n` +
     `style_modifiers: ${JSON.stringify(modifiers)}\n` +
     `# 出力形式\n` +
     `{ "prompt": "相談文", "choices": ["<選択肢1>", "<選択肢2>", "<選択肢3>"], "trust_change": 0, "responses": ["<返答1>", "<返答2>", "<返答3>"] }`

--- a/client/src/prompt/promptBuilder.js
+++ b/client/src/prompt/promptBuilder.js
@@ -93,6 +93,8 @@ export function buildPrompt(eventType, characterA, characterB, context) {
   const talkB = characterB.talkStyle || {}
   core += `\n${characterA.name}の話し方: テンプレート「${talkA.template || '不明'}」 ${talkA.description || ''}`
   core += `\n${characterB.name}の話し方: テンプレート「${talkB.template || '不明'}」 ${talkB.description || ''}`
+  core += `\n${characterA.name}の口調: ${characterA.tone || '指定なし'}`
+  core += `\n${characterB.name}の口調: ${characterB.tone || '指定なし'}`
 
   const interestsA = (characterA.interests || []).join('、') || '特になし'
   const interestsB = (characterB.interests || []).join('、') || '特になし'


### PR DESCRIPTION
## Summary
- store new `tone` field in character data
- allow editing tone in management room
- show tone in character status screen
- include tone in GPT prompt builders

## Testing
- `npm install` *(fails: internet disabled)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885d05e38e48333881160c55e67ae4e