### PR TITLE
リセットボタンの配置変更

### DIFF
--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -24,10 +24,10 @@ export default function Header({ onChangeView, onSave, onLoad, onReset }) {
       <button onClick={() => onChangeView('main')}>ホーム</button>
       <button onClick={() => onChangeView('management')}>管理室</button>
       <button onClick={() => onChangeView('daily')}>日報</button>
-      {/* セーブデータを初期化するリセットボタン */}
-      <button onClick={onReset}>リセット</button>
       <button onClick={onSave}>セーブ</button>
       <button onClick={() => fileInputRef.current?.click()}>ロード</button>
+      {/* セーブデータを初期化するリセットボタン。ロードボタンの右隣に配置 */}
+      <button onClick={onReset}>リセット</button>
       <input
         type="file"
         accept="application/json"


### PR DESCRIPTION
## Summary
- ヘッダー内のボタン配置を調整し、`リセット` ボタンを `ロード` ボタンの右隣へ移動

## Testing
- `npm install` *(failed: network access required)*
- `npm run build` *(failed: vite not found due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6885debc7f608333b267361e3f75d62c