### PR TITLE
チュートリアルステップ7詳細の案内を1秒後に表示

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -436,14 +436,16 @@ export default function App() {
       !tutorialFlags.current.step7Detail
     ) {
       tutorialFlags.current.step7Detail = true
-      showPopup('このように、過去の会話を振り返ることができます。', () => {
-        timer = setTimeout(() => {
-          showPopup('では、ホームに戻りましょう。', () => {
-            setView('main')
-            setState(prev => ({ ...prev, tutorialStep: 8 }))
-          })
-        }, 3000)
-      })
+      timer = setTimeout(() => {
+        showPopup('このように、過去の会話を振り返ることができます。', () => {
+          timer = setTimeout(() => {
+            showPopup('では、ホームに戻りましょう。', () => {
+              setView('main')
+              setState(prev => ({ ...prev, tutorialStep: 8 }))
+            })
+          }, 3000)
+        })
+      }, 1000)
     }
     return () => {
       if (timer) clearTimeout(timer)


### PR DESCRIPTION
## Summary
- 会話詳細画面(ステップ7詳細)での `showPopup` を1秒後に実行するよう変更

## Testing
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885fc7d5c58833389063d5864ce0ed2