### PR TITLE
Implement timestamped save filename

### DIFF
--- a/Code/js/storage.js
+++ b/Code/js/storage.js
@@ -37,7 +37,12 @@ export function exportState(state) {
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = 'state.json';
+    const now = new Date();
+    // ファイル名を「YYYY-M-D-HH:MM.json」の形式で生成
+    const fileName =
+        `${now.getFullYear()}-${now.getMonth() + 1}-${now.getDate()}-${now.getHours()}:` +
+        `${now.getMinutes().toString().padStart(2, '0')}.json`;
+    a.download = fileName;
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);

--- a/client/src/lib/storage.js
+++ b/client/src/lib/storage.js
@@ -41,7 +41,12 @@ export function exportState(state) {
   const url = URL.createObjectURL(blob)
   const a = document.createElement('a')
   a.href = url
-  a.download = 'state.json'
+  const now = new Date()
+  // ファイル名を「YYYY-M-D-HH:MM.json」の形式で生成
+  const fileName =
+    `${now.getFullYear()}-${now.getMonth() + 1}-${now.getDate()}-${now.getHours()}:` +
+    `${now.getMinutes().toString().padStart(2, '0')}.json`
+  a.download = fileName
   document.body.appendChild(a)
   a.click()
   document.body.removeChild(a)


### PR DESCRIPTION
## Summary
- set exported save data filename to include current timestamp

## Testing
- `npm --version`
- `npm install` *(fails: network access blocked)*
- `npm run build` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68860080bfd48333b3cbfaa4133d9bb3