### PR TITLE
Add serverless proxy for OpenAI calls

### DIFF
--- a/api/generateDialogue.js
+++ b/api/generateDialogue.js
@@ -1,0 +1,48 @@
+export default async function handler(req, res) {
+  // POST 以外のリクエストは拒否
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method Not Allowed' })
+    return
+  }
+
+  const apiKey = process.env.OPENAI_API_KEY
+  if (!apiKey) {
+    res.status(500).json({ error: 'OpenAI APIキーが設定されていません' })
+    return
+  }
+
+  try {
+    const { prompt } = req.body
+
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${apiKey}`
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o',
+        messages: [
+          { role: 'system', content: 'あなたは登場人物のセリフを書き出すAIです。' },
+          { role: 'user', content: prompt }
+        ],
+        temperature: 0.85,
+        max_tokens: 800
+      })
+    })
+
+    const data = await response.json()
+
+    if (!response.ok) {
+      console.error('OpenAI APIエラー:', data)
+      res.status(response.status).json({ error: data.error?.message || 'GPT呼び出しに失敗しました' })
+      return
+    }
+
+    const text = data.choices[0].message.content.trim()
+    res.status(200).json({ text })
+  } catch (err) {
+    console.error('API処理中にエラーが発生しました:', err)
+    res.status(500).json({ error: 'サーバーエラー' })
+  }
+}

--- a/client/src/gpt/generateDialogue.js
+++ b/client/src/gpt/generateDialogue.js
@@ -1,34 +1,22 @@
-const apiKey = import.meta.env.VITE_OPENAI_API_KEY
-if (!apiKey) {
-  throw new Error("OpenAI APIキーが設定されていません")
-}
-
 export async function generateDialogue(promptText) {
-  const response = await fetch("https://api.openai.com/v1/chat/completions", {
-    method: "POST",
+  // サーバー側の API にリクエストを転送する
+  const response = await fetch('/api/generateDialogue', {
+    method: 'POST',
     headers: {
-      "Content-Type": "application/json",
-      "Authorization": `Bearer ${apiKey}`
+      'Content-Type': 'application/json'
     },
-    body: JSON.stringify({
-      model: "gpt-4o",
-      messages: [
-        { role: "system", content: "あなたは登場人物のセリフを書き出すAIです。" },
-        { role: "user", content: promptText }
-      ],
-      temperature: 0.85,
-      max_tokens: 800
-    })
+    body: JSON.stringify({ prompt: promptText })
   })
 
   const data = await response.json()
 
   if (!response.ok) {
-    console.error("OpenAI APIエラー:", data)
-    throw new Error(data.error?.message || "GPT呼び出しに失敗しました")
+    console.error('APIエラー:', data)
+    throw new Error(data.error || 'GPT呼び出しに失敗しました')
   }
 
-  return data.choices[0].message.content.trim()
+  // サーバーから返されたテキストのみを利用
+  return data.text
 }
 
 // デバッグ実行ブロック: Node.js で直接実行されたときのみ動作
@@ -36,6 +24,6 @@ if (typeof process !== 'undefined' && process.argv[1] === new URL(import.meta.ur
   const samplePrompt = `キャラクターAとBが夕方に二人で話しています。会話スタイル["open", "gentle"]。関係は友達。雰囲気はややポジティブ。5ターンの会話を自然に書いてください。`
 
   generateDialogue(samplePrompt).then(result => {
-    console.log("GPT出力:\n", result)
+    console.log('GPT出力:\n', result)
   })
 }


### PR DESCRIPTION
## Summary
- secure API key by routing calls through `/api/generateDialogue`
- update client function to call the new serverless endpoint

## Testing
- `npm --prefix client run build` *(fails: vite not found)*
- `npm --prefix client install` *(fails: network disabled)*

------
https://chatgpt.com/codex/tasks/task_e_688608fe93dc8333a352c4ee289bd1b7