### PR TITLE
イベント発生間隔を15分に変更

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -22,7 +22,7 @@ import {
   getCharacterCondition,
   getDateString
 } from './lib/timeUtils.js'
-const EVENT_INTERVAL_MS = 1800000 // 30分ごと
+const EVENT_INTERVAL_MS = 900000 // 15分ごと
 const EVENT_PROBABILITY = 0.7
 
 // 初期状態を Code/js/state.js の構造に合わせて定義


### PR DESCRIPTION
## Summary
- イベント発生タイミングを 30 分ごとから 15 分ごとに短縮

## Testing
- `npm install` *(fails: could not reach registry)*
- `npm run build` *(fails: vite not found due to failed install)*

------
https://chatgpt.com/codex/tasks/task_e_68873017ecd48333b119a3b45a0daa27