### PR TITLE
Add tutorial skip button

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -622,6 +622,17 @@ export default function App() {
     }, 500)
   }
 
+  const handleSkipTutorial = () => {
+    setShowIntro(false)
+    setIsStarting(false)
+    setView('main')
+    setInitialized(true)
+    for (const key of Object.keys(tutorialFlags.current)) {
+      tutorialFlags.current[key] = true
+    }
+    setState(prev => ({ ...prev, tutorialStep: 9 }))
+  }
+
 
   // チュートリアル用コールバック
   const handleFirstRegisterComplete = () => {
@@ -813,6 +824,7 @@ export default function App() {
           onNewGame={handleNewGame}
           showIntro={showIntro}
           onIntroFinish={handleIntroFinish}
+          onSkipTutorial={handleSkipTutorial}
         />
       ) : (
         <>

--- a/client/src/components/StartScreen.jsx
+++ b/client/src/components/StartScreen.jsx
@@ -1,7 +1,13 @@
 import React, { useRef, useState, useEffect, useMemo } from 'react'
 
 // スタート画面。続きから始める・新しく始めるの選択肢を表示する
-export default function StartScreen({ onContinue, onNewGame, showIntro, onIntroFinish }) {
+export default function StartScreen({
+  onContinue,
+  onNewGame,
+  showIntro,
+  onIntroFinish,
+  onSkipTutorial,
+}) {
   const fileInputRef = useRef(null)
   // 元の導入文。句点(「。」)で区切って段落に変換する
   const rawTexts = [
@@ -86,7 +92,10 @@ export default function StartScreen({ onContinue, onNewGame, showIntro, onIntroF
             <p className="mb-4 whitespace-pre-wrap font-mono">{typing}</p>
           )}
           {finished.length === texts.length && !typing && (
-            <button onClick={onIntroFinish}>▶ はじめる</button>
+            <>
+              <button onClick={onIntroFinish}>▶ はじめる</button>
+              <button onClick={onSkipTutorial} className="mt-2">チュートリアルをスキップ</button>
+            </>
           )}
         </>
       )}


### PR DESCRIPTION
## Summary
- add `onSkipTutorial` prop to `StartScreen`
- add new skip button at the end of intro text
- implement `handleSkipTutorial` in `App`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887338ec8f8833397e40f34fc0348b1