### PR TITLE
Fix repeated consultation popup

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -837,7 +837,7 @@ export default function App() {
       {view === 'main' && (
         <MainView
           consultRef={consultRef}
-          onTutorialComplete={handleConsultTutorialComplete}
+          onTutorialComplete={state.tutorialStep === 4 ? handleConsultTutorialComplete : null}
           characters={state.characters}
           logs={state.logs}
           readLogCount={state.readLogCount}


### PR DESCRIPTION
## Summary
- avoid repeating tutorial popup after tutorials

## Testing
- `npm install` *(fails: blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688735daeae08333b31f90b80693bed0