### PR TITLE
Fix login redirect

### DIFF
--- a/client/src/components/SettingsPage.jsx
+++ b/client/src/components/SettingsPage.jsx
@@ -88,7 +88,7 @@ export default function SettingsPage({ onSave, onLoad, onReset }) {
     try {
       await signInWithPopup(auth, new GoogleAuthProvider())
       if (!auth.currentUser.isAnonymous) {
-        window.location.reload()
+        navigate('/settings', { replace: true })
       }
     } catch (e) {
       alert('ログインに失敗しました')
@@ -101,7 +101,7 @@ export default function SettingsPage({ onSave, onLoad, onReset }) {
       const cred = EmailAuthProvider.credential(loginEmail, loginPassword)
       await signInWithCredential(auth, cred)
       if (!auth.currentUser.isAnonymous) {
-        window.location.reload()
+        navigate('/settings', { replace: true })
       }
     } catch (e) {
       alert('ログインに失敗しました')


### PR DESCRIPTION
## Summary
- ensure Google/Email login redirects to `/settings` instead of reloading

## Testing
- `npm install` *(fails: network offline)*

------
https://chatgpt.com/codex/tasks/task_e_6888937d64408333a2d6cd1124a3744a