### PR TITLE
Show email handle in account display

### DIFF
--- a/client/src/components/SettingsPage.jsx
+++ b/client/src/components/SettingsPage.jsx
@@ -114,9 +114,11 @@ export default function SettingsPage({ onSave, onLoad, onReset }) {
   const providerIds = user.providerData?.map(p => p.providerId) || []
   const linkedGoogle = providerIds.includes('google.com')
   const linkedEmail = providerIds.includes('password')
+  // メールアドレスの @ より前の部分を取得し、先頭3文字だけ返す
   const getShortName = info => {
-    const name = info?.displayName || info?.email || ''
-    return name.slice(0, 3)
+    const email = info?.email || ''
+    const account = email.split('@')[0]
+    return account.slice(0, 3)
   }
   const googleInfo = user.providerData.find(p => p.providerId === 'google.com')
   const emailInfo = user.providerData.find(p => p.providerId === 'password')


### PR DESCRIPTION
## Summary
- tweak SettingsPage to display the first three characters of the email handle instead of the account display name when indicating linked accounts

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68889aeb38a08333a28750c7c677a7ac