### PR TITLE
Add log detail navigation from daily report

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -52,6 +52,9 @@ const initialState = {
 
 export default function App() {
   const navigate = useNavigate()
+  const handleOpenLog = (logId) => {
+    navigate(`/daily/log/${logId}`)
+  }
   const location = useLocation()
 
   const [isStarting, setIsStarting] = useState(true)
@@ -977,6 +980,7 @@ export default function App() {
                 <DailyReport
                   reports={state.reports}
                   characters={state.characters}
+                  onOpenLog={handleOpenLog}
                 />
               }
             />


### PR DESCRIPTION
## Summary
- navigate to log detail from daily report view
- pass navigation handler from App.jsx

## Testing
- `npm install` *(fails: unable to reach registry)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889c9ebe4f88333953e06378d57eb86