### PR TITLE
Schedule auto event generation and stabilize Firestore client

### DIFF
--- a/client/src/firebaseConfig.js
+++ b/client/src/firebaseConfig.js
@@ -1,6 +1,6 @@
 import { initializeApp } from "firebase/app";
 import { getAuth, onAuthStateChanged, signInAnonymously } from "firebase/auth";
-import { getFirestore } from "firebase/firestore";
+import { initializeFirestore } from "firebase/firestore";
 // functions を利用するためにインポート
 import { getFunctions } from "firebase/functions";
 
@@ -16,7 +16,10 @@ const firebaseConfig = {
 
 const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);
-const db = getFirestore(app);
+const db = initializeFirestore(app, {
+  ignoreUndefinedProperties: true,
+  experimentalAutoDetectLongPolling: true,
+});
 // functions を初期化（リージョンはFunction側と合わせます）
 const functions = getFunctions(app, "asia-northeast1");
 


### PR DESCRIPTION
## Summary
- convert the auto event generator to a Firebase v2 scheduled function running every 15 minutes in asia-northeast1
- ensure global function options include the default region and retain deletion callable support
- initialize Firestore with experimental auto-detected long polling for more stable client connections

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ecc4996e60833385c07ca51b5978cd